### PR TITLE
Changed Port/Instance Configuration for Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.2 - 2018-11-08
+### Changed
+- If both port and instance are not specified will default to port 1433
+
 ## 0.1.1 - 2018-10-18
 ### Removed
 - Comment from definition file

--- a/mssql-config.yml.sample
+++ b/mssql-config.yml.sample
@@ -7,7 +7,7 @@ instances:
       hostname: <Host name or IP address of the SQl Server>
       username: <Microsoft SQL Server connection user name>
       password: <Microsoft SQL Server connection password>
-      instance: <The Microsoft SQL Server instance to connect to. Use do not supply port if this is specified>
+      instance: <The Microsoft SQL Server instance to connect to. Do not supply port if this is specified>
       port: <Microsoft SQL Server port to connect to. Only needed when instance not specified>
       enable_ssl: <true or false. Indicates if SSL encryption should be used>
       trust_server_certificate: <true or false. If true server certificate is not verified for SSL. If false certificate will be verified against supplied certificate>

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
+	"github.com/newrelic/infra-integrations-sdk/log"
 )
 
 // ArgumentList struct that holds all MSSQL arguments
@@ -31,8 +32,11 @@ func (al ArgumentList) Validate() error {
 		return errors.New("invalid configuration: must specify a hostname")
 	}
 
-	if (al.Port != "" && al.Instance != "") || (al.Port == "" && al.Instance == "") {
-		return errors.New("invalid configuration: must specify one of port or instance")
+	if al.Port != "" && al.Instance != "" {
+		return errors.New("invalid configuration: specify either port or instance but not both")
+	} else if al.Port == "" && al.Instance == "" {
+		log.Info("Both port and instance were not specified using default port of 1433")
+		al.Port = "1433"
 	}
 
 	if al.EnableSSL && (!al.TrustServerCertificate && al.CertificateLocation == "") {

--- a/src/args/argument_list_test.go
+++ b/src/args/argument_list_test.go
@@ -43,7 +43,7 @@ func TestValidate(t *testing.T) {
 				Username: "user",
 				Hostname: "localhost",
 			},
-			true,
+			false,
 		},
 		{
 			"Port and Instance",

--- a/src/mssql.go
+++ b/src/mssql.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.mssql"
-	integrationVersion = "0.1.1"
+	integrationVersion = "0.1.2"
 )
 
 func main() {


### PR DESCRIPTION
#### Description of the changes

Changed how port and instance configuration work. If both are omitted will use default port of `1433`

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
