### PR TITLE
Update executable prefix from nr- to nri-.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.0 (2019-11-18)
+### Changed
+- Renamed the integration executable from nr-mssql to nri-mssql in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.
 ## 2.0.7 - 2019-11-11
 ### Changed
 - Add `enable_buffer_metrics` (default true) option, which allows disabling resource-intensive buffer metrics

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TARGET_DIR    = $(WORKDIR)/$(TARGET)
 NATIVEOS	 := $(shell go version | awk -F '[ /]' '{print $$4}')
 NATIVEARCH	 := $(shell go version | awk -F '[ /]' '{print $$5}')
 INTEGRATION  := mssql
-BINARY_NAME   = nr-$(INTEGRATION)
+BINARY_NAME   = nri-$(INTEGRATION)
 GO_FILES     := ./src/
 GOTOOLS       = github.com/kardianos/govendor \
 		gopkg.in/alecthomas/gometalinter.v2 \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ DEALLOCATE db_cursor
 
 - download an archive file for the `MSSQL` Integration
 - extract `mssql-definition.yml` and `/bin` directory into `/var/db/newrelic-infra/newrelic-integrations`
-- add execute permissions for the binary file `nr-mssql` (if required)
+- add execute permissions for the binary file `nri-mssql` (if required)
 - extract `mssql-config.yml.sample` into `/etc/newrelic-infra/integrations.d`
 
 ## Usage
@@ -65,13 +65,13 @@ Assuming that you have source code you can build and run the MSSQL Integration l
 ```bash
 $ make
 ```
-* The command above will execute tests for the MSSQL Integration and build an executable file called `nr-mssql` in `bin` directory.
+* The command above will execute tests for the MSSQL Integration and build an executable file called `nri-mssql` in `bin` directory.
 ```bash
-$ ./bin/nr-mssql
+$ ./bin/nri-mssql
 ```
-* If you want to know more about usage of `./nr-mssql` check
+* If you want to know more about usage of `./nri-mssql` check
 ```bash
-$ ./bin/nr-mssql -help
+$ ./bin/nri-mssql -help
 ```
 
 For managing external dependencies [govendor tool](https://github.com/kardianos/govendor) is used. It is required to lock all external dependencies to specific version (if possible) into vendor directory.

--- a/mssql-definition.yml
+++ b/mssql-definition.yml
@@ -6,6 +6,6 @@ os: linux
 commands:
   all_data:
     command:
-      - ./bin/nr-mssql
+      - ./bin/nri-mssql
     prefix: config/mssql
     interval: 15

--- a/mssql-win-definition.yml
+++ b/mssql-win-definition.yml
@@ -6,6 +6,6 @@ os: windows
 commands:
   all_data:
     command:
-      - .\bin\nr-mssql.exe
+      - .\bin\nri-mssql.exe
     prefix: config/mssql
     interval: 15

--- a/pkg/windows/nri-amd64-installer/Product.wxs.template
+++ b/pkg/windows/nri-amd64-installer/Product.wxs.template
@@ -74,8 +74,7 @@
             </Component>
         </ComponentGroup>
         <ComponentGroup Id="CustomPluginsComponent" Directory="CustomPluginsFolder">
-            <Component Id="CMP_NRI_{IntegrationName}_DEFINITION_YML" Guid="35c84fd9-7b1a-4871-a706-390ea19252b1" Win64="yes"
-                       NeverOverwrite="yes" Permanent="yes">
+            <Component Id="CMP_NRI_{IntegrationName}_DEFINITION_YML" Guid="35c84fd9-7b1a-4871-a706-390ea19252b1" Win64="yes">
                 <File Id="FILE_NRI_{IntegrationName}_DEFINITION_YML"
                       Name="{IntegrationName}-definition.yml"
                       Source="$(var.ProjectRootPath){IntegrationName}-win-definition.yml"

--- a/src/mssql.go
+++ b/src/mssql.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.mssql"
-	integrationVersion = "2.0.7"
+	integrationVersion = "2.1.0"
 )
 
 func main() {

--- a/win_build.ps1
+++ b/win_build.ps1
@@ -15,7 +15,7 @@ param (
 
 $integration = $(Split-Path -Leaf $PSScriptRoot)
 $integrationName = $integration.Replace("nri-", "")
-$executable = "nr-$integrationName.exe"
+$executable = "nri-$integrationName.exe"
 
 # verifying version number format
 $v = $version.Split(".")

--- a/windows_set_version.ps1
+++ b/windows_set_version.ps1
@@ -7,7 +7,7 @@ param (
 
 $integration = $(Split-Path -Leaf $PSScriptRoot)
 $integrationName = $integration.Replace("nri-", "")
-$executable = "nr-$integrationName.exe"
+$executable = "nri-$integrationName.exe"
 
 if (-not (Test-Path env:GOPATH)) {
 	Write-Error "GOPATH not defined."


### PR DESCRIPTION
### Changed
- Renamed the integration executable from nr-mssql to nri-mssql in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.