### PR TITLE
Add custom metrics query argument

### DIFF
--- a/mssql-config.yml.sample
+++ b/mssql-config.yml.sample
@@ -18,6 +18,13 @@ instances:
       trust_server_certificate: <true or false. If true server certificate is not verified for SSL. If false certificate will be verified against supplied certificate>
       certificate_location: <Location of the SSL Certificate. Do not specify if trust_server_certificate is set to true>
       timeout: <Timeout in seconds for a single SQL Query Execution. Set 0 for no timeout>
+      # custom_metrics_query: >-
+      #   select
+      #     'rows_inserted' as "metric_name",
+      #     'delta' as "metric_type",
+      #     sd.tup_inserted as "metric_value",
+      #     sd.datid as "database_id"
+      #   from pg_stat_database sd;
     labels:
       env: production
       role: mssql

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -21,6 +21,7 @@ type ArgumentList struct {
 	CertificateLocation    string `default:"" help:"Certificate file to verify SSL encryption against"`
 	EnableBufferMetrics    bool   `default:"true" help:"Enable collection of buffer space metrics."`
 	Timeout                string `default:"30" help:"Timeout in seconds for a single SQL Query. Set 0 for no timeout"`
+	CustomMetricsQuery     string `default:"" help:"A SQL query to collect custom metrics. Must have the columns metric_name, metric_type, and metric_value. Additional columns are added as attributes"`
 }
 
 // Validate validates SQL specific arguments

--- a/src/connection/sql_connection.go
+++ b/src/connection/sql_connection.go
@@ -44,6 +44,11 @@ func (sc SQLConnection) Query(v interface{}, query string) error {
 	return sc.Connection.Select(v, query)
 }
 
+// Queryx runs a query and returns a set of rows
+func (p SQLConnection) Queryx(query string) (*sqlx.Rows, error) {
+	return p.Connection.Queryx(query)
+}
+
 // CreateConnectionURL tags in args and creates the connection string.
 // All args should be validated before calling this.
 func CreateConnectionURL(args *args.ArgumentList) string {


### PR DESCRIPTION
This commit adds support for a `custom_metrics_query` argument. The
argument must be a SQL query string that has the columns 'metric_name',
'metric_value', and 'metric_type'. Additional columns are not required,
but if they exist, they will be added to the metric set as attributes
where the column name is the attribute key and the value for that row is the
attribute value.

#### Description of the changes

Add a detailed description and purpose of your changes.
Link the issue it solves (if there is one).

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
