### PR TITLE
Update populateCustomMetrics() for queries in YAML, auto-detect metric type

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,45 @@ In order to use the MSSQL Integration it is required to configure `mssql-config.
 
 You can view your data in Insights by creating your own custom NRQL queries. To do so use the **MssqlDatabaseSample**, **MssqlInstanceSample** event type.
 
+## Custom Queries
+
+To add custom queries, use the **-custom_metrics_query** option to provide a single query, or the **-custom_metrics_config** option to specify a YAML file with one or more queries, such as the sample `mssql-custom-query.yml.sample`
+
+### How attributes are named
+
+Each query that returns a table of values will be parsed row by row, adding the **MssqlCustomQuerySample** event as follows:
+
+- The column name is the attribute name
+- Each row value in that column is the attribute value
+- The metric type is auto-detected whether it is a number (type GAUGE), or a string (type ATTRIBUTE)
+
+One customizable attribute in each row can be configured by database values using the following names:
+
+- The column `metric_name` specifies its attribute name
+- The column `metric_value` specifies its attribute value
+- The column `metric_type` specifies its metric type, i.e. `gauge` or `attribute`
+
+For example, the following query makes attributes named `category_0`, `category_1`, `category_2` and so on.
+```sql
+SELECT CONCAT('category_', category_id) AS metric_name, name AS metric_value, category_type FROM syscategories
+```
+
+### Specifying queries in YAML
+
+When using a YAML file containing queries, you can specify the following parameters for each query:
+
+- `query` (required) contains the SQL query
+- `database` (optional) Prepends `USE <database name>; ` to the SQL, and adds the database name as an attribute
+- `prefix` (optional) prefix to prepend to the attribute name
+- `metric_name` (optional) specify the name for the customizable attribute
+- `metric_type` (optional) specify the metric type for the customizable attribute
+
 ## Compatibility
 
 * Supported OS: Windows version compatible with the New Relic Infrastructure Agent
 * MS SQL Server versions: SQL Server 2008 R2+
+
+Note:  It also seems to work on Linux for the containerized Linux version of MSSQL
 
 ## Integration Development usage
 

--- a/mssql-custom-query.yml.sample
+++ b/mssql-custom-query.yml.sample
@@ -1,0 +1,10 @@
+queries: 
+    # Example for metric_name / metric_type specified in this config
+  - query: SELECT count(*) AS 'metric_value' FROM sys.databases
+    metric_name: dbCount
+    metric_type: gauge
+    # Example for metric_name from query, metric_type auto-detected, additional attribute 'category_type'
+  - query: SELECT CONCAT('category_', category_id) AS metric_name, name AS metric_value, category_type FROM syscategories
+    database: msdb
+    # Example for stored procedure 'exec dbo.sp_server_info @attribute_id = 2'
+  - query: dbo.sp_server_info @attribute_id = 2

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -3,6 +3,7 @@ package args
 
 import (
 	"errors"
+	"os"
 
 	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
 	"github.com/newrelic/infra-integrations-sdk/log"
@@ -21,7 +22,8 @@ type ArgumentList struct {
 	CertificateLocation    string `default:"" help:"Certificate file to verify SSL encryption against"`
 	EnableBufferMetrics    bool   `default:"true" help:"Enable collection of buffer space metrics."`
 	Timeout                string `default:"30" help:"Timeout in seconds for a single SQL Query. Set 0 for no timeout"`
-	CustomMetricsQuery     string `default:"" help:"A SQL query to collect custom metrics. Must have the columns metric_name, metric_type, and metric_value. Additional columns are added as attributes"`
+	CustomMetricsQuery     string `default:"" help:"A SQL query to collect custom metrics. Query results 'metric_name', 'metric_value', and 'metric_type' have special meanings"`
+	CustomMetricsConfig    string `default:"" help:"YAML configuration with one or more SQL queries to collect custom metrics"`
 }
 
 // Validate validates SQL specific arguments
@@ -43,6 +45,15 @@ func (al ArgumentList) Validate() error {
 
 	if al.EnableSSL && (!al.TrustServerCertificate && al.CertificateLocation == "") {
 		return errors.New("invalid configuration: must specify a certificate file when using SSL and not trusting server certificate")
+	}
+
+	if len(al.CustomMetricsConfig) > 0 {
+		if len(al.CustomMetricsQuery) > 0 {
+			return errors.New("cannot specify options custom_metrics_query and custom_metrics_config")
+		}
+		if _, err := os.Stat(al.CustomMetricsConfig); err != nil {
+			return errors.New("custom_metrics_config argument: " + err.Error())
+		}
 	}
 
 	return nil

--- a/src/mssql.go
+++ b/src/mssql.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.mssql"
-	integrationVersion = "2.2.1"
+	integrationVersion = "2.3.0"
 )
 
 func main() {


### PR DESCRIPTION
#### Description of the changes

- Added new command line option `-custom_metrics_config` for queries in YAML
- Included sample config `mssql-custom-query.yml.sample`
- Update `-custom_metrics_query` to auto-detect type
- Support for `exec procedure` with YAML queries

#### PR Review Checklist
### Author

- Risk is only to custom queries command-line options
- Tested on several examples, it looks ok

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
