### PR TITLE
fix: sql instance entity name was being reported incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.5.1 (2020-07-29)
+### Fixed
+- MSSQL instances were being reported with only the host name instead of the full instance name
+
 ## 2.5.0 (2020-07-13)
 ### Changed
 - Updated the MSSQL driver

--- a/src/instance/sql_instance.go
+++ b/src/instance/sql_instance.go
@@ -30,7 +30,7 @@ func CreateInstanceEntity(i *integration.Integration, con *connection.SQLConnect
 
 	if instanceRows[0].Name.Valid {
 		instanceNameIDAttr := integration.NewIDAttribute("instance", instanceRows[0].Name.String)
-		return i.EntityReportedVia(con.Host, con.Host, "ms-instance", instanceNameIDAttr)
+		return i.EntityReportedVia(con.Host, instanceRows[0].Name.String, "ms-instance", instanceNameIDAttr)
 	}
 
 	return i.EntityReportedVia(con.Host, con.Host, "ms-instance")

--- a/src/instance/sql_instance_test.go
+++ b/src/instance/sql_instance_test.go
@@ -64,7 +64,7 @@ func Test_createInstanceEntity(t *testing.T) {
 	entity, err := CreateInstanceEntity(i, conn)
 	assert.Nil(t, err)
 
-	assert.Equal(t, "testhost", entity.Metadata.Name)
+	assert.Equal(t, "testinstance", entity.Metadata.Name)
 	assert.Equal(t, "ms-instance", entity.Metadata.Namespace)
 	assert.Len(t, entity.Metadata.IDAttrs, 1)
 }

--- a/src/mssql.go
+++ b/src/mssql.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.mssql"
-	integrationVersion = "2.5.0"
+	integrationVersion = "2.5.1"
 )
 
 func main() {


### PR DESCRIPTION
MSSQL instances were being reported with only the host name instead of the full instance name