### PR TITLE
fix: disable upgrade package test

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -108,6 +108,7 @@ jobs:
         with:
           tag: ${{ env.TAG }}
           integration: nri-${{ env.INTEGRATION }}
+          upgrade: false
 
   package-win:
     name: Create MSI & Upload into GH Release assets


### PR DESCRIPTION
[Current package](http://download.newrelic.com/infrastructure_agent/linux/apt/pool/main/n/nri-mssql/nri-mssql_0.1.5-1_amd64.deb) in repo is too old and has a different configfile specification for .deb. this causes that the installation test upgrade path prompts a message to replace the definition file and makes the test fail since that is not being handled.

The goal of This PR is to disable this test (upgrade path) for the first package. 
I have perfomed the test locally and if the prompt is answered the integrations upgrades successfully.