### PR TITLE
include "nolock" in total disk space query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.8.3  (2022-08-17)
+### Changed
+- Improve error handling and debug logs for custom queries
+- Avoid potential deadlocks in disk space query
+
 ## 2.8.2  (2022-06-27)
 ### Changed
 - Bump dependencies

--- a/src/metrics/instance_metric_definitions.go
+++ b/src/metrics/instance_metric_definitions.go
@@ -107,7 +107,7 @@ var instanceDefinitions = []*QueryDefinition{
 			dovs.volume_mount_point,
 			dovs.available_bytes available_bytes,
 			dovs.total_bytes total_bytes
-			FROM sys.master_files mf
+			FROM sys.master_files mf WITH (nolock)
 			CROSS apply sys.Dm_os_volume_stats(mf.database_id, mf.file_id) dovs
 			) drives`,
 		dataModels: &[]struct {


### PR DESCRIPTION
Avoids potential deadlocks when other queries are blocking this particular table (E.g.: conflicting RESTORE LOG).