### PR TITLE
fix resultSet bug in custom queries

### DIFF
--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -153,15 +153,13 @@ func populateCustomMetrics(instanceEntity *integration.Entity, connection *conne
 		return
 	}
 
-	if !rows.NextResultSet() {
-		log.Warn("No result set found for custom query: %+v", query)
-	}
-
 	defer func() {
 		_ = rows.Close()
 	}()
 
+	var rowCount = 0
 	for rows.Next() {
+		rowCount++
 		row := make(map[string]interface{})
 		err := rows.MapScan(row)
 		if err != nil {
@@ -262,6 +260,11 @@ func populateCustomMetrics(instanceEntity *integration.Entity, connection *conne
 				log.Error("Failed to set metric: %s", err)
 			}
 		}
+	}
+	if rowCount == 0 {
+		log.Warn("No result set found for custom query: %+v", query)
+	} else {
+		log.Debug("%v Rows returned for custom query: %+v", rowCount, query)
 	}
 
 	if err := rows.Err(); err != nil {


### PR DESCRIPTION
This PR fixes an issue with nextResultSet used to retrieve the presence of results from a custom query.
This had an unexpected effect of moving to the nextResultSet which prevented us to walk the records for the first result set returned causing custom queries to always return an empty set of records.