### PR TITLE
fix: include misning env variable for testing packages build

### DIFF
--- a/build/ci.mk
+++ b/build/ci.mk
@@ -83,6 +83,7 @@ ifdef TAG
 			-e INTEGRATION \
 			-e PRERELEASE=true \
 			-e NO_PUBLISH=true \
+			-e NO_SIGN \
 			-e GITHUB_TOKEN \
 			-e REPO_FULL_NAME \
 			-e TAG \


### PR DESCRIPTION
It makes [Test binary compilation and packaging for linux](https://github.com/newrelic/nri-mssql/actions/runs/5801595470/job/15742702128?pr=129) fail due to missing signature credentials.

<img width="773" alt="image" src="https://github.com/newrelic/nri-mssql/assets/442627/6cdc9216-883e-43ad-a698-a1c4a1a5263b">

Package signature is not supposed to be tested there.