### PR TITLE
[NR-302034] fix: handle DECIMAL values in custom queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 
 ## Unreleased
-
-### bugfix
+### bugfix
 - Handle DECIMAL values in custom queries
 
 ## v2.12.7 - 2024-09-10
 
 ### ⛓️ Dependencies
 - Updated golang version to v1.23.1
-
-## bugfix
 - (deps) move from github.com/denisenkom/go-mssqldb to github.com/microsoft/go-mssqldb
 
 ## v2.12.6 - 2024-07-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+- Handle DECIMAL values in custom queries
+
 ## v2.12.7 - 2024-09-10
 
 ### ⛓️ Dependencies

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 integration-test:
 	@echo "=== $(INTEGRATION) === [ test ]: running integration tests..."
 	@docker compose -f tests/docker-compose.yml pull
-	@go test -v -tags=integration ./tests/. || (ret=$$?; docker compose -f tests/docker-compose.yml down && exit $$ret)
+	@go test -count=1 -v -tags=integration ./tests/. || (ret=$$?; docker compose -f tests/docker-compose.yml down && exit $$ret)
 	@docker compose -f tests/docker-compose.yml down
 
 compile: 

--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,11 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+godebug (
+// Allows TLS certs with negative serial numbers.
+// Before go 1.23 these certificates where accepted, now the corresponding go debug variable is needed
+// to restore the previous behavior
+// <https://cs.opensource.google/go/go/+/refs/tags/go1.23.1:src/crypto/x509/parser.go;l=1019>
+	x509negativeserial=1
+)

--- a/src/metrics/metrics_test.go
+++ b/src/metrics/metrics_test.go
@@ -2,7 +2,7 @@ package metrics
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -23,7 +23,7 @@ var (
 
 func updateGoldenFile(data []byte, sourceFile string) error {
 	if *update {
-		return ioutil.WriteFile(sourceFile, data, 0644)
+		return os.WriteFile(sourceFile, data, 0644)
 	}
 	return nil
 }
@@ -44,7 +44,7 @@ func createTestEntity(t *testing.T) (i *integration.Integration, e *integration.
 }
 
 func checkAgainstFile(t *testing.T, data []byte, expectedFile string) {
-	expectedData, err := ioutil.ReadFile(expectedFile)
+	expectedData, err := os.ReadFile(expectedFile)
 	if err != nil {
 		t.Errorf("Could not read expected file: %v", err.Error())
 	}
@@ -216,5 +216,91 @@ func Test_populateWaitTimeMetrics(t *testing.T) {
 	expectedFile := filepath.Join("..", "testdata", "waitTime.json.golden")
 	assert.NoError(t, updateGoldenFile(actual, expectedFile))
 
+	checkAgainstFile(t, actual, expectedFile)
+}
+
+func Test_populateCustomMetricsInQuery(t *testing.T) {
+	i, e := createTestEntity(t)
+
+	query := `SELECT
+				'myMetric' as metric_name,
+				value as metric_value,
+				'gauge' as metric_type,
+				value2 as 'otherValue'
+				attr as 'attrValue'
+			FROM my_table, LIMIT 2`
+
+	conn, mock := connection.CreateMockSQL(t)
+	defer conn.Close()
+
+	customQueryRows := sqlmock.NewRows([]string{"metric_name", "metric_value", "metric_type", "otherValue", "attrValue"}).
+		AddRow("myMetric", 0.5, "gauge", 42, "aa").
+		AddRow("myMetric", 1.5, "gauge", 43, "bb")
+
+	mock.ExpectQuery(query).WillReturnRows(customQueryRows)
+	mock.ExpectClose()
+
+	cq := customQuery{Query: query}
+
+	populateCustomMetrics(e, conn, cq)
+
+	actual, _ := i.MarshalJSON()
+	expectedFile := filepath.Join("..", "testdata", "customQuery.json")
+	checkAgainstFile(t, actual, expectedFile)
+}
+
+func Test_populateCustomMetricsInConfig(t *testing.T) {
+	i, e := createTestEntity(t)
+
+	query := `SELECT
+				value as metric_value,
+				value2 as 'otherValue'
+				attr as 'attrValue'
+			FROM my_table`
+
+	conn, mock := connection.CreateMockSQL(t)
+	defer conn.Close()
+
+	customQueryRows := sqlmock.NewRows([]string{"metric_value", "otherValue", "attrValue"}).
+		AddRow(0.5, 42, "aa").
+		AddRow(1.5, 43, "bb")
+
+	mock.ExpectQuery(query).WillReturnRows(customQueryRows)
+	mock.ExpectClose()
+
+	cq := customQuery{Query: query, Name: "myMetric", Type: "gauge"}
+
+	populateCustomMetrics(e, conn, cq)
+
+	actual, _ := i.MarshalJSON()
+	expectedFile := filepath.Join("..", "testdata", "customQuery.json")
+	checkAgainstFile(t, actual, expectedFile)
+}
+
+func Test_populateCustomMetricsInConfigDetectTypeAndPrefix(t *testing.T) {
+	i, e := createTestEntity(t)
+
+	query := `SELECT
+				value as metric_value,
+				value2 as 'otherValue'
+				attr as 'attrValue'
+			FROM my_table`
+
+	conn, mock := connection.CreateMockSQL(t)
+	defer conn.Close()
+
+	customQueryRows := sqlmock.NewRows([]string{"metric_value", "otherValue", "attrValue"}).
+		AddRow(0.5, 42, "aa").
+		AddRow(1.5, 43, "bb")
+
+	mock.ExpectQuery(query).WillReturnRows(customQueryRows)
+	mock.ExpectClose()
+
+	cq := customQuery{Query: query, Name: "myMetric", Prefix: "prefix_"}
+
+	populateCustomMetrics(e, conn, cq)
+
+	actual, _ := i.MarshalJSON()
+	expectedFile := filepath.Join("..", "testdata", "customQueryPrefix.json")
 	checkAgainstFile(t, actual, expectedFile)
 }

--- a/src/testdata/customQuery.json
+++ b/src/testdata/customQuery.json
@@ -1,0 +1,38 @@
+{
+    "name": "test",
+    "protocol_version": "3",
+    "integration_version": "1.0.0",
+    "data": [
+        {
+            "entity": {
+                "name": "test",
+                "type": "instance",
+                "id_attributes": []
+            },
+            "metrics": [
+                {
+                    "attrValue": "aa",
+                    "displayName": "test",
+                    "entityName": "instance:test",
+                    "event_type": "MssqlCustomQuerySample",
+                    "host": "testhost",
+                    "instance": "test",
+                    "myMetric": 0.5,
+                    "otherValue": 42
+                },
+                {
+                    "attrValue": "bb",
+                    "displayName": "test",
+                    "entityName": "instance:test",
+                    "event_type": "MssqlCustomQuerySample",
+                    "host": "testhost",
+                    "instance": "test",
+                    "myMetric": 1.5,
+                    "otherValue": 43
+                }
+            ],
+            "inventory": {},
+            "events": []
+        }
+    ]
+}

--- a/src/testdata/customQueryPrefix.json
+++ b/src/testdata/customQueryPrefix.json
@@ -1,0 +1,38 @@
+{
+    "name": "test",
+    "protocol_version": "3",
+    "integration_version": "1.0.0",
+    "data": [
+        {
+            "entity": {
+                "name": "test",
+                "type": "instance",
+                "id_attributes": []
+            },
+            "metrics": [
+                {
+                    "prefix_attrValue": "aa",
+                    "displayName": "test",
+                    "entityName": "instance:test",
+                    "event_type": "MssqlCustomQuerySample",
+                    "host": "testhost",
+                    "instance": "test",
+                    "prefix_myMetric": 0.5,
+                    "prefix_otherValue": 42
+                },
+                {
+                    "prefix_attrValue": "bb",
+                    "displayName": "test",
+                    "entityName": "instance:test",
+                    "event_type": "MssqlCustomQuerySample",
+                    "host": "testhost",
+                    "instance": "test",
+                    "prefix_myMetric": 1.5,
+                    "prefix_otherValue": 43
+                }
+            ],
+            "inventory": {},
+            "events": []
+        }
+    ]
+}

--- a/tests/mssql_test.go
+++ b/tests/mssql_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package tests
 

--- a/tests/mssql_test.go
+++ b/tests/mssql_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package tests
@@ -42,8 +43,8 @@ func waitForMSSQLIsUpAndRunning(maxTries int) bool {
 	}
 	fmt.Println(stdout)
 	fmt.Println(stderr)
-	log.Info("try to establish de connection with the mssql database...")
 	for ; maxTries > 0; maxTries-- {
+		time.Sleep(5 * time.Second)
 		log.Info("try to establish de connection with the mssql database...")
 
 		conn, err := connection.NewConnection(&args.ArgumentList{
@@ -54,7 +55,6 @@ func waitForMSSQLIsUpAndRunning(maxTries int) bool {
 		})
 		if err != nil {
 			log.Warn(err.Error())
-			time.Sleep(5 * time.Second)
 			continue
 		}
 		if conn != nil {


### PR DESCRIPTION
This PR updates the function handling custom queries in order that it can parse DECIMAL values.

The previous implementation was scanning all the values into `interface{}` values, which means that the driver performs no conversion, and later it was converting all the values to string, to finally try to convert to `Float64` for the corresponding types. This wasn't working well because the driver represents DECIMAL values as `uint8[]` and the corresponding conversion to string was an array of bytes. We have updated it to directly scan the values into the `string` type (which tells the driver to perform the corresponding conversion) and later, we keep converting the strings to numbers only when needed.

The PR also includes a small refactor of the function handling custom queries and some unit-test to try to assure its behavior doesn't change.

