### PR TITLE
add argument to disable disk-space-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 
 ## Unreleased
+### Enhancement
+- Add `enable_disk_metrics_in_bytes` argument (default true), allows disabling disk-space-metrics
 
 ## v2.13.0 - 2024-10-08
 

--- a/mssql-config.yml.sample
+++ b/mssql-config.yml.sample
@@ -19,6 +19,7 @@ integrations:
 
     # ENABLE_BUFFER_METRICS: true
     # ENABLE_DATABASE_RESERVE_METRICS: true 
+    # ENABLE_DISK_METRICS_IN_BYTES: true
 
     # YAML configuration with one or more SQL queries to collect custom metrics
     # CUSTOM_METRICS_CONFIG: ""

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -27,7 +27,7 @@ type ArgumentList struct {
 	CustomMetricsConfig          string `default:"" help:"YAML configuration with one or more SQL queries to collect custom metrics"`
 	ShowVersion                  bool   `default:"false" help:"Print build information and exit"`
 	ExtraConnectionURLArgs       string `default:"" help:"Appends additional parameters to connection url. Ex. 'applicationintent=readonly&foo=bar'"`
-	EnableDiskMetricsInBytes     bool   `default:"true" help:"Enable collection of disk space metrics in bytes."`
+	EnableDiskMetricsInBytes     bool   `default:"true" help:"Enable collection of instance.diskInBytes."`
 }
 
 // Validate validates SQL specific arguments

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -27,6 +27,7 @@ type ArgumentList struct {
 	CustomMetricsConfig          string `default:"" help:"YAML configuration with one or more SQL queries to collect custom metrics"`
 	ShowVersion                  bool   `default:"false" help:"Print build information and exit"`
 	ExtraConnectionURLArgs       string `default:"" help:"Appends additional parameters to connection url. Ex. 'applicationintent=readonly&foo=bar'"`
+	EnableDiskMetricsInBytes     bool   `default:"true" help:"Enable collection of disk space metrics in bytes."`
 }
 
 // Validate validates SQL specific arguments

--- a/src/metrics/instance_metric_definitions.go
+++ b/src/metrics/instance_metric_definitions.go
@@ -109,19 +109,6 @@ var instanceDefinitions = []*QueryDefinition{
 		}{},
 	},
 	{
-		query: `SELECT Sum(total_bytes) AS total_disk_space FROM (
-			SELECT DISTINCT
-			dovs.volume_mount_point,
-			dovs.available_bytes available_bytes,
-			dovs.total_bytes total_bytes
-			FROM sys.master_files mf WITH (nolock)
-			CROSS apply sys.Dm_os_volume_stats(mf.database_id, mf.file_id) dovs
-			) drives`,
-		dataModels: &[]struct {
-			TotalDiskSpace *int64 `db:"total_disk_space" metric_name:"instance.diskInBytes" source_type:"gauge"`
-		}{},
-	},
-	{
 		query: `SELECT Sum(runnable_tasks_count) AS runnable_tasks_count
 		FROM sys.dm_os_schedulers
 		WHERE   scheduler_id < 255 AND [status] = 'VISIBLE ONLINE'`,
@@ -171,4 +158,20 @@ type waitTimeModel struct {
 	WaitType  *string `db:"wait_type"`
 	WaitTime  *int64  `db:"wait_time"`
 	WaitCount *int64  `db:"waiting_tasks_count"`
+}
+
+var diskMetricInBytesDefination = []*QueryDefinition{
+	{
+		query: `SELECT Sum(total_bytes) AS total_disk_space FROM (
+			SELECT DISTINCT
+			dovs.volume_mount_point,
+			dovs.available_bytes available_bytes,
+			dovs.total_bytes total_bytes
+			FROM sys.master_files mf WITH (nolock)
+			CROSS apply sys.Dm_os_volume_stats(mf.database_id, mf.file_id) dovs
+			) drives`,
+		dataModels: &[]struct {
+			TotalDiskSpace *int64 `db:"total_disk_space" metric_name:"instance.diskInBytes" source_type:"gauge"`
+		}{},
+	},
 }

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -48,6 +48,9 @@ func PopulateInstanceMetrics(instanceEntity *integration.Entity, connection *con
 	if arguments.EnableBufferMetrics {
 		collectionList = append(collectionList, instanceBufferDefinitions...)
 	}
+	if arguments.EnableDiskMetricsInBytes {
+		collectionList = append(collectionList, diskMetricInBytesDefination...)
+	}
 
 	for _, queryDef := range collectionList {
 		models := queryDef.GetDataModels()

--- a/src/metrics/metrics_test.go
+++ b/src/metrics/metrics_test.go
@@ -159,7 +159,8 @@ func Test_populateInstanceMetrics(t *testing.T) {
 	mock.ExpectClose()
 
 	args := args.ArgumentList{
-		EnableBufferMetrics: true,
+		EnableBufferMetrics:      true,
+		EnableDiskMetricsInBytes: true,
 	}
 	PopulateInstanceMetrics(e, conn, args)
 


### PR DESCRIPTION
Add `enable_disk_metrics_in_bytes` argument (default true), allows disabling disk-space-metrics


Docs PR https://github.com/newrelic/docs-website/pull/19312