### PR TITLE
fix: handle null values while populating custom query metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+- handle null values while populating custom query metrics
+
 ## v2.17.0 - 2025-02-19
 
 ### 🚀 Enhancements

--- a/src/testdata/customQueryNull.json
+++ b/src/testdata/customQueryNull.json
@@ -1,0 +1,65 @@
+{
+    "name": "test",
+    "protocol_version": "3",
+    "integration_version": "1.0.0",
+    "data": [
+        {
+            "entity": {
+                "name": "test",
+                "type": "instance",
+                "id_attributes": []
+            },
+            "metrics": [
+                {
+                    "prefix_attrValue": "",
+                    "displayName": "test",
+                    "entityName": "instance:test",
+                    "event_type": "MssqlCustomQuerySample",
+                    "host": "testhost",
+                    "instance": "test",
+                    "prefix_myMetric": 0.5,
+                    "prefix_otherValue": ""
+                },
+                {
+                    "prefix_attrValue": "",
+                    "displayName": "test",
+                    "entityName": "instance:test",
+                    "event_type": "MssqlCustomQuerySample",
+                    "host": "testhost",
+                    "instance": "test",
+                    "prefix_myMetric": 1.5,
+                    "prefix_otherValue": 43
+                },
+                {
+                    "prefix_attrValue": "cc",
+                    "displayName": "test",
+                    "entityName": "instance:test",
+                    "event_type": "MssqlCustomQuerySample",
+                    "host": "testhost",
+                    "instance": "test",
+                    "prefix_myMetric": 2.5,
+                    "prefix_otherValue": ""
+                },
+                {
+                    "displayName": "test",
+                    "entityName": "instance:test",
+                    "event_type": "MssqlCustomQuerySample",
+                    "host": "testhost",
+                    "instance": "test"
+                },
+                {
+                    "prefix_attrValue": "dd",
+                    "displayName": "test",
+                    "entityName": "instance:test",
+                    "event_type": "MssqlCustomQuerySample",
+                    "host": "testhost",
+                    "instance": "test",
+                    "prefix_myMetric": 4.5,
+                    "prefix_otherValue": 45
+                }
+            ],
+            "inventory": {},
+            "events": []
+        }
+    ]
+}


### PR DESCRIPTION
What this PR fixes: Report `MssqlCustomQuerySample` data if there is NULL value in the output of the `CUSTOM_METRICS_QUERY`.

Changes in this PR:

1. Using sql.NullString while scanning rows of the custom query output. If the custom query output has null values a check is added to verify and set it as empty string, proceed with scanning other rows instead of failing.
2. Added unit tests for the same.

Testing details can be found [here](https://new-relic.atlassian.net/browse/NR-365328?focusedCommentId=1141678)

