### PR TITLE
 Add Query monitoring only flag and refactor queries file

### DIFF
--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -32,6 +32,7 @@ type ArgumentList struct {
 	QueryMonitoringResponseTimeThreshold int    `default:"500" help:"Threshold in milliseconds for query response time. If response time exceeds this threshold, the query will be considered slow."`
 	QueryMonitoringCountThreshold        int    `default:"20" help:"Maximum number of queries returned in query analysis results."`
 	QueryMonitoringFetchInterval         int    `default:"15" help:"Interval in seconds for fetching grouped slow queries; Should always be same as mysql-config interval."`
+	QueryMonitoringOnly                  bool   `default:"false" help:"If true, only query monitoring will be executed."`
 }
 
 // Validate validates SQL specific arguments

--- a/src/connection/sql_connection.go
+++ b/src/connection/sql_connection.go
@@ -50,6 +50,10 @@ func (sc SQLConnection) Queryx(query string) (*sqlx.Rows, error) {
 	return sc.Connection.Queryx(query)
 }
 
+func (sc SQLConnection) QueryxWithParemeters(query string, args ...interface{}) (*sqlx.Rows, error) {
+	return sc.Connection.Queryx(query, args...)
+}
+
 // CreateConnectionURL tags in args and creates the connection string.
 // All args should be validated before calling this.
 func CreateConnectionURL(args *args.ArgumentList) string {

--- a/src/mssql.go
+++ b/src/mssql.go
@@ -72,6 +72,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if args.QueryMonitoringOnly {
+		queryanalysis.PopulateQueryPerformanceMetrics(i, args)
+		return
+	}
+
 	// Inventory collection
 	if args.HasInventory() {
 		inventory.PopulateInventory(instanceEntity, con)

--- a/src/queryanalysis/config/config.go
+++ b/src/queryanalysis/config/config.go
@@ -1,0 +1,31 @@
+package config
+
+// Documentation: https:https://newrelic.atlassian.net/wiki/x/SYFq6g
+// The above link contains all the queries, data models, and query details for QueryAnalysis.
+
+// We need to use this limit of long strings that we are injesting because the logs datastore in New Relic limits the field length to 4,094 characters. Any data longer than that is truncated during ingestion.
+const TextTruncateLimit = 4094
+
+const (
+	// QueryResponseTimeThresholdDefault defines the default threshold in milliseconds
+	// for determining if a query is considered slow based on its response time.
+	QueryResponseTimeThresholdDefault = 500
+
+	// SlowQueryCountThresholdDefault sets the default maximum number of slow queries
+	// that is ingested in an analysis cycle/interval.
+	SlowQueryCountThresholdDefault = 20
+
+	// IndividualQueryCountMax represents the maximum number of individual queries
+	// that is ingested at one time for any grouped query in detailed analysis.
+	IndividualQueryCountMax = 10
+
+	// GroupedQueryCountMax specifies the maximum number of grouped queries
+	// that is ingested in  an analysis cycle/interval.
+	GroupedQueryCountMax = 30
+
+	// MaxSystemDatabaseID indicates the highest database ID value considered
+	// a system database, used to filter out system databases from certain operations.
+	MaxSystemDatabaseID = 4
+	BatchSize           = 600 // New Relic's Integration SDK imposes a limit of 1000 metrics per ingestion.To handle metric sets exceeding this limit, we process and ingest metrics in smaller chunks to ensure all data is successfully reported without exceeding the limit.
+
+)

--- a/src/queryanalysis/queries/queries.go
+++ b/src/queryanalysis/queries/queries.go
@@ -1,9 +1,7 @@
-package config
+package queries
 
 import "github.com/newrelic/nri-mssql/src/queryanalysis/models"
 
-// Documentation: https:https://newrelic.atlassian.net/wiki/x/SYFq6g
-// The above link contains all the queries, data models, and query details for QueryAnalysis.
 var Queries = []models.QueryDetailsDto{
 	{
 		EventName: "MSSQLTopSlowQueries",
@@ -349,30 +347,3 @@ SELECT *
 FROM PlanNodes
 ORDER BY plan_handle, NodeId;
 `
-
-// We need to use this limit of long strings that we are injesting because the logs datastore in New Relic limits the field length to 4,094 characters. Any data longer than that is truncated during ingestion.
-const TextTruncateLimit = 4094
-
-const (
-	// QueryResponseTimeThresholdDefault defines the default threshold in milliseconds
-	// for determining if a query is considered slow based on its response time.
-	QueryResponseTimeThresholdDefault = 500
-
-	// SlowQueryCountThresholdDefault sets the default maximum number of slow queries
-	// that is ingested in an analysis cycle/interval.
-	SlowQueryCountThresholdDefault = 20
-
-	// IndividualQueryCountMax represents the maximum number of individual queries
-	// that is ingested at one time for any grouped query in detailed analysis.
-	IndividualQueryCountMax = 10
-
-	// GroupedQueryCountMax specifies the maximum number of grouped queries
-	// that is ingested in  an analysis cycle/interval.
-	GroupedQueryCountMax = 30
-
-	// MaxSystemDatabaseID indicates the highest database ID value considered
-	// a system database, used to filter out system databases from certain operations.
-	MaxSystemDatabaseID = 4
-	BatchSize           = 600 // New Relic's Integration SDK imposes a limit of 1000 metrics per ingestion.To handle metric sets exceeding this limit, we process and ingest metrics in smaller chunks to ensure all data is successfully reported without exceeding the limit.
-
-)

--- a/src/queryanalysis/query_analysis.go
+++ b/src/queryanalysis/query_analysis.go
@@ -5,7 +5,8 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"github.com/newrelic/nri-mssql/src/args"
 	"github.com/newrelic/nri-mssql/src/connection"
-	"github.com/newrelic/nri-mssql/src/queryanalysis/config"
+	"github.com/newrelic/nri-mssql/src/queryanalysis/queries"
+
 	"github.com/newrelic/nri-mssql/src/queryanalysis/utils"
 	"github.com/newrelic/nri-mssql/src/queryanalysis/validation"
 )
@@ -31,7 +32,7 @@ func PopulateQueryPerformanceMetrics(integration *integration.Integration, argum
 
 	utils.ValidateAndSetDefaults(&arguments)
 
-	queries := config.Queries
+	queries := queries.Queries
 	queryDetails, err := utils.LoadQueries(queries, arguments)
 	if err != nil {
 		log.Error("Error loading query configuration: %v", err)

--- a/src/queryanalysis/utils/utils.go
+++ b/src/queryanalysis/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/newrelic/nri-mssql/src/queryanalysis/queries"
 	"regexp"
 	"strconv"
 	"strings"
@@ -171,7 +172,7 @@ func ProcessExecutionPlans(arguments args.ArgumentList, integration *integration
 }
 
 func GenerateAndIngestExecutionPlan(arguments args.ArgumentList, integration *integration.Integration, sqlConnection *connection.SQLConnection, queryIDString string) {
-	executionPlanQuery := fmt.Sprintf(config.ExecutionPlanQueryTemplate, min(config.IndividualQueryCountMax, arguments.QueryMonitoringCountThreshold),
+	executionPlanQuery := fmt.Sprintf(queries.ExecutionPlanQueryTemplate, min(config.IndividualQueryCountMax, arguments.QueryMonitoringCountThreshold),
 		arguments.QueryMonitoringResponseTimeThreshold, queryIDString, arguments.QueryMonitoringFetchInterval, config.TextTruncateLimit)
 
 	var model models.ExecutionPlanResult

--- a/src/queryanalysis/utils/utils_test.go
+++ b/src/queryanalysis/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"github.com/newrelic/nri-mssql/src/queryanalysis/queries"
 	"testing"
 	"time"
 
@@ -327,7 +328,7 @@ func checkStringField(t *testing.T, name string, field *string, expected string)
 }
 
 func TestLoadQueries_SlowQueries(t *testing.T) {
-	configQueries := config.Queries
+	configQueries := queries.Queries
 	var arguments args.ArgumentList
 
 	slowQueriesIndex := -1
@@ -343,7 +344,7 @@ func TestLoadQueries_SlowQueries(t *testing.T) {
 		t.Fatalf("could not find 'slowQueries' in the list of queries")
 	}
 
-	queries, err := LoadQueries(config.Queries, arguments)
+	queries, err := LoadQueries(queries.Queries, arguments)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -359,7 +360,7 @@ func TestLoadQueries_SlowQueries(t *testing.T) {
 // nolint: dupl
 func TestLoadQueries_WaitAnalysis(t *testing.T) {
 	// Initial Configuration and Argument Setup\
-	configQueries := config.Queries
+	configQueries := queries.Queries
 	var args args.ArgumentList
 
 	// Prepare Arguments
@@ -385,7 +386,7 @@ func TestLoadQueries_WaitAnalysis(t *testing.T) {
 		configQueries[waitQueriesIndex].Query, args.QueryMonitoringCountThreshold, config.TextTruncateLimit)
 
 	// Invoke the function under test
-	queries, err := LoadQueries(config.Queries, args)
+	queries, err := LoadQueries(queries.Queries, args)
 	assert.Nil(t, err, "expected no error, got an error instead")
 
 	// Verify that the "waitAnalysis" query was modified as expected
@@ -395,7 +396,7 @@ func TestLoadQueries_WaitAnalysis(t *testing.T) {
 // nolint: dupl
 func TestLoadQueries_BlockingSessions(t *testing.T) {
 	// Initial Configuration and Argument Setup
-	configQueries := config.Queries
+	configQueries := queries.Queries
 	var args args.ArgumentList
 
 	// Prepare Arguments
@@ -421,7 +422,7 @@ func TestLoadQueries_BlockingSessions(t *testing.T) {
 		configQueries[blockQueriesIndex].Query, args.QueryMonitoringCountThreshold, config.TextTruncateLimit)
 
 	// Invoke the function under test
-	queries, err := LoadQueries(config.Queries, args)
+	queries, err := LoadQueries(queries.Queries, args)
 	assert.Nil(t, err, "expected no error, got an error instead")
 
 	// Verify that the "blockingSessions" query was modified as expected
@@ -429,7 +430,7 @@ func TestLoadQueries_BlockingSessions(t *testing.T) {
 }
 
 func TestLoadQueries_UnknownType(t *testing.T) {
-	config.Queries = []models.QueryDetailsDto{
+	queries.Queries = []models.QueryDetailsDto{
 		{
 			EventName: "UnknownTypeQuery",
 			Query:     "SELECT * FROM mysterious_table",
@@ -444,7 +445,7 @@ func TestLoadQueries_UnknownType(t *testing.T) {
 	}
 
 	// Call the function under test
-	_, err := LoadQueries(config.Queries, args)
+	_, err := LoadQueries(queries.Queries, args)
 	if err == nil {
 		t.Fatalf("expected error for unknown query type, got nil")
 	}
@@ -458,8 +459,8 @@ func TestLoadQueries_UnknownType(t *testing.T) {
 
 // utils_test.go
 func TestLoadQueries_AllTypes_AllFormats(t *testing.T) {
-	// Setup: Ensure config.Queries uses all %d format specifiers as intended
-	config.Queries = []models.QueryDetailsDto{
+	// Setup: Ensure queries.Queries uses all %d format specifiers as intended
+	queries.Queries = []models.QueryDetailsDto{
 		{
 			EventName: "MSSQLTopSlowQueries",
 			Type:      "slowQueries",
@@ -488,21 +489,21 @@ func TestLoadQueries_AllTypes_AllFormats(t *testing.T) {
 		{
 			EventName: "MSSQLTopSlowQueries",
 			Type:      "slowQueries",
-			Query:     fmt.Sprintf(config.Queries[0].Query, sampleArgs.QueryMonitoringFetchInterval, sampleArgs.QueryMonitoringCountThreshold, sampleArgs.QueryMonitoringResponseTimeThreshold, config.TextTruncateLimit),
+			Query:     fmt.Sprintf(queries.Queries[0].Query, sampleArgs.QueryMonitoringFetchInterval, sampleArgs.QueryMonitoringCountThreshold, sampleArgs.QueryMonitoringResponseTimeThreshold, config.TextTruncateLimit),
 		},
 		{
 			EventName: "MSSQLWaitTimeAnalysis",
 			Type:      "waitAnalysis",
-			Query:     fmt.Sprintf(config.Queries[1].Query, sampleArgs.QueryMonitoringCountThreshold, config.TextTruncateLimit),
+			Query:     fmt.Sprintf(queries.Queries[1].Query, sampleArgs.QueryMonitoringCountThreshold, config.TextTruncateLimit),
 		},
 		{
 			EventName: "MSSQLBlockingSessionQueries",
 			Type:      "blockingSessions",
-			Query:     fmt.Sprintf(config.Queries[2].Query, sampleArgs.QueryMonitoringCountThreshold, config.TextTruncateLimit),
+			Query:     fmt.Sprintf(queries.Queries[2].Query, sampleArgs.QueryMonitoringCountThreshold, config.TextTruncateLimit),
 		},
 	}
 	// Execute the function
-	loadedQueries, err := LoadQueries(config.Queries, sampleArgs)
+	loadedQueries, err := LoadQueries(queries.Queries, sampleArgs)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -528,8 +529,8 @@ func TestLoadQueries_AllTypes_AllFormats(t *testing.T) {
 }
 
 func TestLoadQueries_EmptyConfig(t *testing.T) {
-	// Setup: Empty config.Queries
-	config.Queries = []models.QueryDetailsDto{}
+	// Setup: Empty queries.Queries
+	queries.Queries = []models.QueryDetailsDto{}
 
 	// Setup: Sample ArgumentList
 	sampleArgs := args.ArgumentList{
@@ -539,7 +540,7 @@ func TestLoadQueries_EmptyConfig(t *testing.T) {
 	}
 
 	// Execute the function
-	loadedQueries, err := LoadQueries(config.Queries, sampleArgs)
+	loadedQueries, err := LoadQueries(queries.Queries, sampleArgs)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
1. Add only the Query Monitoring tag.
2. Refactor the `query_config.go` file by separating the queries and constants.
