### PR TITLE
Add changelog for v2.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+## v2.17.2 - 2025-03-12
+
+### 🐞 Bug fixes
+- handle null values while populating custom query metrics
+
 ## v2.17.1 - 2025-03-11
 
 ### 🐞 Bug fixes


### PR DESCRIPTION
[Pre release](https://github.com/newrelic/nri-mssql/releases/tag/v2.17.1) broke mid [pipeline](https://github.com/newrelic/nri-mssql/actions/runs/13784792445/job/38550972442#step:3:473) so re releasing with a the tag 2.17.2