### PR TITLE
Bugfix: changed elapsed_time from ms to us

### DIFF
--- a/mssql-custom-query.yml.sample
+++ b/mssql-custom-query.yml.sample
@@ -159,8 +159,8 @@ queries:
         qs.total_logical_reads/qs.execution_count AS [logical_reads_avg],
         qs.total_logical_writes AS [logical_writes_total],
         qs.total_logical_writes/qs.execution_count AS [logical_writes_avg],
-        qs.total_elapsed_time AS [duration_total_ms],
-        qs.total_elapsed_time/qs.execution_count AS [duration_avg_ms],
+        qs.total_elapsed_time AS [duration_total_us],
+        qs.total_elapsed_time/qs.execution_count AS [duration_avg_us],
         qs.creation_time AS [creation_time],
         qs.last_execution_time AS [last_execution_time],
         t.[text] AS [complete_text]


### PR DESCRIPTION
Team,

I just found out, that in custom query "Example for top 15 longest running queries", there is a value "total_elapsed_time AS [duration_total_ms]", which is being used as duration(in milliseconds).

However, the Microsoft documentation says, that total_elapsed_time from sys.dm_exec_query_stats table is being reported in microseconds, no milliseconds.

Quote from documentation:
"Total elapsed time, reported in microseconds (but only accurate to milliseconds), for completed executions of this plan."

MS doc link: https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-exec-query-stats-transact-sql?view=sql-server-ver16

I believe, to avoid confusion for the NewRelic users, it would make sense to rename the fields and replace the time suffix from 'ms' to 'us'(which means microseconds).

Thanks,
Eduard