### PR TITLE
NR-401130: Added version support of Azure SQL in nri-mssql.

### DIFF
--- a/src/queryanalysis/validation/sql_server_version.go
+++ b/src/queryanalysis/validation/sql_server_version.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	versionRegexPattern        = `\b(\d+\.\d+\.\d+)\b`
-	getSQLServerVersionQuery   = "SELECT @@VERSION"
-	lastSupportedVersion       = 16
-	firstSupportedVersion      = 14
+	versionRegexPattern      = `\b(\d+\.\d+\.\d+)\b`
+	getSQLServerVersionQuery = "SELECT @@VERSION"
+	lastSupportedVersion     = 16
+	firstSupportedVersion    = 14
+	// Represents the first supported version for Azure SQL Server in the cloud.
 	azureFirstSupportedVersion = 12
 )
 

--- a/src/queryanalysis/validation/sql_server_version.go
+++ b/src/queryanalysis/validation/sql_server_version.go
@@ -17,6 +17,7 @@ const (
 	lastSupportedVersion     = 16
 	firstSupportedVersion    = 14
 	// Represents the first supported version for Azure SQL Server in the cloud.
+	azureLastSupportedVersion  = 16
 	azureFirstSupportedVersion = 12
 )
 
@@ -60,7 +61,7 @@ func checkSQLServerVersion(sqlConnection *connection.SQLConnection) (bool, error
 		return false, err
 	}
 	if strings.Contains(strings.ToLower(serverVersion), "azure") {
-		return version.Major >= azureFirstSupportedVersion && version.Major <= lastSupportedVersion, nil
+		return version.Major >= azureFirstSupportedVersion && version.Major <= azureLastSupportedVersion, nil
 	}
 	return version.Major >= firstSupportedVersion && version.Major <= lastSupportedVersion, nil
 }

--- a/src/queryanalysis/validation/sql_server_version.go
+++ b/src/queryanalysis/validation/sql_server_version.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/newrelic/nri-mssql/src/connection"
 
@@ -11,10 +12,11 @@ import (
 )
 
 const (
-	versionRegexPattern      = `\b(\d+\.\d+\.\d+)\b`
-	getSQLServerVersionQuery = "SELECT @@VERSION"
-	lastSupportedVersion     = 16
-	firstSupportedVersion    = 14
+	versionRegexPattern        = `\b(\d+\.\d+\.\d+)\b`
+	getSQLServerVersionQuery   = "SELECT @@VERSION"
+	lastSupportedVersion       = 16
+	firstSupportedVersion      = 14
+	azureFirstSupportedVersion = 12
 )
 
 var (
@@ -55,6 +57,9 @@ func checkSQLServerVersion(sqlConnection *connection.SQLConnection) (bool, error
 	version, err := parseSQLServerVersion(serverVersion)
 	if err != nil {
 		return false, err
+	}
+	if strings.Contains(strings.ToLower(serverVersion), "azure") {
+		return version.Major >= azureFirstSupportedVersion && version.Major <= lastSupportedVersion, nil
 	}
 	return version.Major >= firstSupportedVersion && version.Major <= lastSupportedVersion, nil
 }

--- a/src/queryanalysis/validation/sql_server_version.go
+++ b/src/queryanalysis/validation/sql_server_version.go
@@ -16,9 +16,9 @@ const (
 	getSQLServerVersionQuery = "SELECT @@VERSION"
 	lastSupportedVersion     = 16
 	firstSupportedVersion    = 14
-	// Represents the first supported version for Azure SQL Server in the cloud.
-	azureLastSupportedVersion  = 16
+	// Defines the supported version range for Azure SQL Server in the cloud, from version 12 to 16.
 	azureFirstSupportedVersion = 12
+	azureLastSupportedVersion  = 16
 )
 
 var (

--- a/src/queryanalysis/validation/sql_server_version_test.go
+++ b/src/queryanalysis/validation/sql_server_version_test.go
@@ -22,6 +22,32 @@ func TestCheckSqlServerVersion_SupportedVersion(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestCheckSqlServerVersion_AzureSupportedVersion(t *testing.T) {
+	sqlConnection, mock := setupMockDB(t)
+	defer sqlConnection.Connection.Close()
+
+	// Mocking a supported Azure SQL Server version response
+	mock.ExpectQuery(regexp.QuoteMeta(getSQLServerVersionQuery)).
+		WillReturnRows(sqlmock.NewRows([]string{"@@VERSION"}).AddRow("Microsoft SQL Azure (RTM) - 12.0.2000.8"))
+
+	result, _ := checkSQLServerVersion(sqlConnection)
+	assert.True(t, result)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCheckSqlServerVersion_AzureUnsupportedVersion(t *testing.T) {
+	sqlConnection, mock := setupMockDB(t)
+	defer sqlConnection.Connection.Close()
+
+	// Mocking an unsupported Azure SQL Server version response
+	mock.ExpectQuery(regexp.QuoteMeta(getSQLServerVersionQuery)).
+		WillReturnRows(sqlmock.NewRows([]string{"@@VERSION"}).AddRow("Microsoft SQL Azure (RTM) - 11.0.2000.7"))
+
+	result, _ := checkSQLServerVersion(sqlConnection)
+	assert.False(t, result)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestCheckSqlServerVersion_UnsupportedVersion(t *testing.T) {
 	sqlConnection, mock := setupMockDB(t)
 	defer sqlConnection.Connection.Close()

--- a/src/queryanalysis/validation/sql_server_version_test.go
+++ b/src/queryanalysis/validation/sql_server_version_test.go
@@ -29,7 +29,9 @@ func TestCheckSQLServerVersionforAzure(t *testing.T) {
 		expected bool
 	}{
 		{"AzureSupportedVersion", "Microsoft SQL Azure (RTM) - 12.0.2000.8", true},
-		{"AzureUnsupportedVersion", "Microsoft SQL Azure (RTM) - 11.0.2000.7", false},
+		{"AzureUnsupportedVersion", "Microsoft SQL azure (RTM) - 11.0.2000.7", false},
+		{"AzureUnsupportedVersion", "Microsoft SQL (RTM) - 12.0.2000.8", false},
+		{"AzureUnsupportedVersion", "Microsoft SQL Azure (RTM) - 17.0.2000.8", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
What it does ?

Added support for Microsoft SQL Azure (RTM) - 12.0.2000.8 in the nri-mssql. The current nri-mssql versions support standard SQL from major version numbers 14 to 16. This PR extends support to include versions 12 to 14 specifically for Azure SQL, with the Azure cloud currently using version 12. Support up to version 16 has been included for future compatibility."

Testing:

The test cases for Azure SQL version were executed with the scenarios listed below, and all tests passed successfully.
1) go test -v -run TestCheckSQLServerVersionforAzure
