### PR TITLE
add funcs that identify azure sql database

### DIFF
--- a/src/database/sql_database.go
+++ b/src/database/sql_database.go
@@ -15,7 +15,7 @@ import (
 // databaseNameQuery gets all database names
 const databaseNameQuery = "select name as db_name from sys.databases where name not in ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')"
 const engineEditionQuery = "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition;"
-const azureSQLDatabaseEgineEditionNumber = 5
+const azureSQLDatabaseEngineEditionNumber = 5
 
 // NameRow is a row result in the databaseNameQuery
 type NameRow struct {
@@ -131,8 +131,7 @@ func GetEngineEdition(connection *connection.SQLConnection) (int, error) {
 	}
 }
 
-// IsAzureSQLDatabase checks if the given engine edition corresponds to Azure SQL Database.
+// IsAzureSQLDatabase checks if the given engine edition corresponds to Azure SQL Database with EngineEdition value of 5
 func IsAzureSQLDatabase(engineEdition int) bool {
-	// Azure SQL Database has an EngineEdition value of 5.
-	return engineEdition == azureSQLDatabaseEgineEditionNumber
+	return engineEdition == azureSQLDatabaseEngineEditionNumber
 }

--- a/src/database/sql_database.go
+++ b/src/database/sql_database.go
@@ -2,16 +2,20 @@
 package database
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/newrelic/infra-integrations-sdk/v3/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
+	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"github.com/newrelic/nri-mssql/src/connection"
 )
 
 // databaseNameQuery gets all database names
 const databaseNameQuery = "select name as db_name from sys.databases where name not in ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')"
+const engineEditionQuery = "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition;"
+const azureSQLDatabaseEgineEditionNumber = 5
 
 // NameRow is a row result in the databaseNameQuery
 type NameRow struct {
@@ -111,4 +115,24 @@ func CreateDBEntitySetLookup(dbEntities []*integration.Entity, instanceName, hos
 	}
 
 	return entitySetLookup
+}
+
+// GetEngineEdition retrieves the engine edition from the database.
+func GetEngineEdition(connection *connection.SQLConnection) (int, error) {
+	var engineEdition []int
+	if err := connection.Query(&engineEdition, engineEditionQuery); err != nil {
+		return 0, fmt.Errorf("error querying EngineEdition: %w", err)
+	}
+	if len(engineEdition) == 0 {
+		log.Debug("EngineEdition query returned empty output.")
+		return 0, nil
+	} else {
+		return engineEdition[0], nil
+	}
+}
+
+// IsAzureSQLDatabase checks if the given engine edition corresponds to Azure SQL Database.
+func IsAzureSQLDatabase(engineEdition int) bool {
+	// Azure SQL Database has an EngineEdition value of 5.
+	return engineEdition == azureSQLDatabaseEgineEditionNumber
 }

--- a/src/database/sql_database_test.go
+++ b/src/database/sql_database_test.go
@@ -13,6 +13,8 @@ import (
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
+const azureSQLManagedInstanceEngineEditionNumber = 8
+
 func Test_createDatabaseEntities_QueryError(t *testing.T) {
 	i, err := integration.New("test", "1.0.0")
 	if err != nil {
@@ -194,20 +196,20 @@ func TestGetEngineEdition(t *testing.T) {
 			name: "Successful query - Azure SQL DB",
 			setupMock: func(mock sqlmock.Sqlmock) {
 				expectedRows := sqlmock.NewRows([]string{"EngineEdition"}).
-					AddRow(5)
+					AddRow(azureSQLDatabaseEngineEditionNumber)
 				mock.ExpectQuery("SELECT (.+)").WillReturnRows(expectedRows)
 			},
-			expectedEdition: 5,
+			expectedEdition: azureSQLDatabaseEngineEditionNumber,
 			expectError:     false,
 		},
 		{
 			name: "Successful query - Other SQL Server",
 			setupMock: func(mock sqlmock.Sqlmock) {
 				expectedRows := sqlmock.NewRows([]string{"EngineEdition"}).
-					AddRow(3)
+					AddRow(azureSQLManagedInstanceEngineEditionNumber)
 				mock.ExpectQuery("SELECT (.+)").WillReturnRows(expectedRows)
 			},
-			expectedEdition: 3,
+			expectedEdition: azureSQLManagedInstanceEngineEditionNumber,
 			expectError:     false,
 		},
 		{
@@ -253,12 +255,12 @@ func TestIsAzureSQLDatabase(t *testing.T) {
 	}{
 		{
 			name:          "Azure SQL Database",
-			engineEdition: 5,
+			engineEdition: azureSQLDatabaseEngineEditionNumber,
 			expected:      true,
 		},
 		{
 			name:          "Azure SQL Managed Instance",
-			engineEdition: 8,
+			engineEdition: azureSQLManagedInstanceEngineEditionNumber,
 			expected:      false,
 		},
 	}


### PR DESCRIPTION
This PR introduces two new functions:

- GetEngineEdition(connection *SQLConnection) (int, error): This function queries the database to retrieve the SQL Server engine edition. It handles the database interaction, including executing the query and processing the result.  If the query returns no rows, it logs a debug message and returns 0 without an error.

- IsAzureSQLDatabase(engineEdition int) bool: This function determines whether a given engine edition corresponds to Azure SQL Database.  It specifically checks if the engine edition is 5, which is the value for Azure SQL Database.

These functions provide a clear and consistent way to obtain and interpret the SQL Server engine edition, particularly in the context of differentiating between Azure SQL Database and other SQL Server instances. This information can be used to conditionally execute logic or features based on the database type.

Testing:

Added unit tests for GetEngineEdition, IsAzureSQLDatabase funcs

Manually executed the integration binary against the Azure SQL Database and validated that GetEngineEdition returns 5, IsAzureSQLDatabase true as shown in the below SS.

```shell
root@sairaj-mssql-test-2:/home/sairaj/nri-mssql# make
=== mssql === [ clean ]: Removing binaries and coverage file...
removed 'bin/nri-mssql'
removed directory 'bin'
=== mssql === [ test ]: Running unit tests...
?       github.com/newrelic/nri-mssql/src       [no test files]
ok      github.com/newrelic/nri-mssql/src/args  1.009s
ok      github.com/newrelic/nri-mssql/src/connection    1.009s
ok      github.com/newrelic/nri-mssql/src/database      1.018s
ok      github.com/newrelic/nri-mssql/src/instance      1.012s
ok      github.com/newrelic/nri-mssql/src/inventory     1.014s
?       github.com/newrelic/nri-mssql/src/queryanalysis [no test files]
?       github.com/newrelic/nri-mssql/src/queryanalysis/config  [no test files]
ok      github.com/newrelic/nri-mssql/src/metrics       1.043s
ok      github.com/newrelic/nri-mssql/src/queryanalysis/models  1.007s
ok      github.com/newrelic/nri-mssql/src/queryanalysis/utils   1.044s
?       github.com/newrelic/nri-mssql/tests/simulation  [no test files]
ok      github.com/newrelic/nri-mssql/src/queryanalysis/validation      1.024s
=== mssql === [ compile ]: Building nri-mssql...
root@sairaj-mssql-test-2:/home/sairaj/nri-mssql# cd bin
root@sairaj-mssql-test-2:/home/sairaj/nri-mssql/bin# ./nri-mssql -username="newrelic"  -password="xxx" -port=1433 -hostname="test.windows.net"
 -enable_query_monitoring=true -verbose=true
[DEBUG] Running query: select COALESCE( @@SERVERNAME, SERVERPROPERTY('ServerName'), SERVERPROPERTY('MachineName')) as instance_name
[DEBUG] Running query: SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition;
[DEBUG] getEngineEdition%!(EXTRA int=5)
[DEBUG] isAzureSQLDatabase%!(EXTRA bool=true)
``` 