### PR TITLE
NR-408418: remove Unsupported SQL Queries for Azure SQL Database

### DIFF
--- a/src/common/query_skip.go
+++ b/src/common/query_skip.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"strings"
+
+	"github.com/newrelic/nri-mssql/src/database"
+)
+
+var UnsupportedQueryPatterns = map[int][]string{
+	database.AzureSQLDatabaseEngineEditionNumber: { // Azure SQL Database EngineEdition
+		"sys.dm_os_process_memory",
+		"sys.master_files",
+		"exec sp_configure",
+		"sys.dm_os_sys_memory",
+		"sys.dm_os_volume_stats",
+	},
+}
+
+func ShouldSkipQueryForEngineEdition(engineEdition int, query string) bool {
+	for _, pattern := range UnsupportedQueryPatterns[engineEdition] {
+		if strings.Contains(strings.ToLower(query), strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/database/sql_database.go
+++ b/src/database/sql_database.go
@@ -15,7 +15,7 @@ import (
 // databaseNameQuery gets all database names
 const databaseNameQuery = "select name as db_name from sys.databases where name not in ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')"
 const engineEditionQuery = "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition;"
-const azureSQLDatabaseEngineEditionNumber = 5
+const AzureSQLDatabaseEngineEditionNumber = 5
 
 // NameRow is a row result in the databaseNameQuery
 type NameRow struct {
@@ -133,5 +133,5 @@ func GetEngineEdition(connection *connection.SQLConnection) (int, error) {
 
 // IsAzureSQLDatabase checks if the given engine edition corresponds to Azure SQL Database with EngineEdition value of 5
 func IsAzureSQLDatabase(engineEdition int) bool {
-	return engineEdition == azureSQLDatabaseEngineEditionNumber
+	return engineEdition == AzureSQLDatabaseEngineEditionNumber
 }

--- a/src/database/sql_database_test.go
+++ b/src/database/sql_database_test.go
@@ -196,10 +196,10 @@ func TestGetEngineEdition(t *testing.T) {
 			name: "Successful query - Azure SQL DB",
 			setupMock: func(mock sqlmock.Sqlmock) {
 				expectedRows := sqlmock.NewRows([]string{"EngineEdition"}).
-					AddRow(azureSQLDatabaseEngineEditionNumber)
+					AddRow(AzureSQLDatabaseEngineEditionNumber)
 				mock.ExpectQuery("SELECT (.+)").WillReturnRows(expectedRows)
 			},
-			expectedEdition: azureSQLDatabaseEngineEditionNumber,
+			expectedEdition: AzureSQLDatabaseEngineEditionNumber,
 			expectError:     false,
 		},
 		{
@@ -255,7 +255,7 @@ func TestIsAzureSQLDatabase(t *testing.T) {
 	}{
 		{
 			name:          "Azure SQL Database",
-			engineEdition: azureSQLDatabaseEngineEditionNumber,
+			engineEdition: AzureSQLDatabaseEngineEditionNumber,
 			expected:      true,
 		},
 		{

--- a/src/inventory/inventory_test.go
+++ b/src/inventory/inventory_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/v3/data/inventory"
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/nri-mssql/src/connection"
+	"github.com/newrelic/nri-mssql/src/database"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
@@ -28,59 +29,96 @@ func CreateMockSQL(t *testing.T) (con *connection.SQLConnection, mock sqlmock.Sq
 }
 
 func Test_populateInventory(t *testing.T) {
-	i, err := integration.New("test", "1.0.0")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
+	// Uncomment the following line to enable logging during tests
+	// log.SetupLogging(true)
+	// defer log.SetupLogging(false)
+	tests := []struct {
+		name               string
+		spConfigSetup      func(mock sqlmock.Sqlmock) // Function to mock sp_configure query
+		sysConfigSetup     func(mock sqlmock.Sqlmock) // Function to mock sys.configurations query
+		expectedInventory  map[string]inventory.Item  // Expected inventory items
+		engineEditionValue int                        // Engine edition value
+	}{
+		{
+			name: "Successful inventory population",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
+					AddRow("allow polybase export", 0, 1, 0, 0).
+					AddRow("allow updates", 0, 1, 0, 0)
+				mock.ExpectQuery(spConfigQuery).WillReturnRows(spConfigRows)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
+					AddRow("allow polybase export", 1).
+					AddRow("allow updates", 1)
+				mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/run_value":    {"value": 0},
+				"allow updates/run_value":            {"value": 0},
+				"allow polybase export/config_value": {"value": 1},
+				"allow updates/config_value":         {"value": 1},
+			},
+			engineEditionValue: 3,
+		},
+		{
+			name: "Engine edition 5: Only sys.configurations items collected",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				// No rows/queries expected for sp_configure since it should be skipped
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
+					AddRow("allow polybase export", 1).
+					AddRow("allow updates", 1)
+				mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/config_value": {"value": 1},
+				"allow updates/config_value":         {"value": 1},
+			},
+			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber, // Azure SQL Database
+		},
 	}
 
-	e, err := i.Entity("test", "instance")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i, err := integration.New("test", "1.0.0")
+			if err != nil {
+				t.Fatalf("Unexpected error %s", err.Error())
+			}
 
-	conn, mock := CreateMockSQL(t)
+			e, err := i.Entity("test", "instance")
+			if err != nil {
+				t.Fatalf("Unexpected error %s", err.Error())
+			}
 
-	// SPConfig expect
-	spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
-		AddRow("allow polybase export", 0, 1, 0, 0).
-		AddRow("allow updates", 0, 1, 0, 0)
-	mock.ExpectQuery(spConfigQuery).WillReturnRows(spConfigRows)
+			conn, mock := CreateMockSQL(t)
 
-	// sys.configurations expect
-	sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
-		AddRow("allow polybase export", 1).
-		AddRow("allow updates", 1)
-	mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			// Setup mocks
+			tt.spConfigSetup(mock)
+			tt.sysConfigSetup(mock)
 
-	PopulateInventory(e, conn)
+			PopulateInventory(e, conn, tt.engineEditionValue)
 
-	// expected inventory.Items map to be set
-	expected := map[string]inventory.Item{
-		"allow polybase export/run_value":    {"value": 0},
-		"allow updates/run_value":            {"value": 0},
-		"allow polybase export/config_value": {"value": 1},
-		"allow updates/config_value":         {"value": 1},
-	}
+			// Validate inventory
+			equal := true
+			for k, expectedV := range tt.expectedInventory {
+				v, ok := e.Inventory.Item(k)
+				if !ok {
+					equal = false
+					break
+				}
 
-	// reflect.DeepEqual did not work on comparing Items maps so did a manual comparison
-	equal := true
-	for k, expectedV := range expected {
-		v, ok := e.Inventory.Item(k)
-		if !ok {
-			equal = false
-			break
-		}
+				if !reflect.DeepEqual(expectedV, v) {
+					equal = false
+					break
+				}
+			}
 
-		if !reflect.DeepEqual(expectedV, v) {
-			equal = false
-			break
-		}
-	}
-
-	if !equal {
-		t.Errorf("Expected %+v got %+v", expected, e.Inventory.Items())
+			if !equal {
+				t.Errorf("Expected %+v got %+v", tt.expectedInventory, e.Inventory.Items())
+			}
+		})
 	}
 }
 
@@ -99,6 +137,8 @@ func Test_populateInventory_SPConfigError(t *testing.T) {
 
 	conn, mock := CreateMockSQL(t)
 
+	engineEdition := 3
+
 	// SPConfig expect
 	mock.ExpectQuery(spConfigQuery).WillReturnError(errors.New("error"))
 
@@ -108,7 +148,7 @@ func Test_populateInventory_SPConfigError(t *testing.T) {
 		AddRow("allow updates", 1)
 	mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
 
-	PopulateInventory(e, conn)
+	PopulateInventory(e, conn, engineEdition)
 
 	// expected inventory.Items map to be set
 	expected := map[string]inventory.Item{
@@ -151,6 +191,8 @@ func Test_populateInventory_SysConfigError(t *testing.T) {
 
 	conn, mock := CreateMockSQL(t)
 
+	engineEdition := 3
+
 	// SPConfig expect
 	spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
 		AddRow("allow polybase export", 0, 1, 0, 0).
@@ -160,7 +202,7 @@ func Test_populateInventory_SysConfigError(t *testing.T) {
 	// sys.configurations expect
 	mock.ExpectQuery(sysConfigQuery).WillReturnError(errors.New("error"))
 
-	PopulateInventory(e, conn)
+	PopulateInventory(e, conn, engineEdition)
 
 	// expected inventory.Items map to be set
 	expected := map[string]inventory.Item{

--- a/src/metrics/instance_metric_definitions.go
+++ b/src/metrics/instance_metric_definitions.go
@@ -160,7 +160,7 @@ type waitTimeModel struct {
 	WaitCount *int64  `db:"waiting_tasks_count"`
 }
 
-var diskMetricInBytesDefination = []*QueryDefinition{
+var diskMetricInBytesDefinition = []*QueryDefinition{
 	{
 		query: `SELECT Sum(total_bytes) AS total_disk_space FROM (
 			SELECT DISTINCT

--- a/src/mssql.go
+++ b/src/mssql.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/newrelic/nri-mssql/src/args"
 	"github.com/newrelic/nri-mssql/src/connection"
+	"github.com/newrelic/nri-mssql/src/database"
 	"github.com/newrelic/nri-mssql/src/instance"
 	"github.com/newrelic/nri-mssql/src/inventory"
 	"github.com/newrelic/nri-mssql/src/metrics"
@@ -72,9 +73,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Get EngineEdition
+	engineEdition := 0 // Default to 0 (Unknown)
+	engineEdition, err = database.GetEngineEdition(con)
+	if err != nil {
+		log.Debug("Failed to get engine edition: %v", err)
+	}
+
 	// Inventory collection
 	if args.HasInventory() {
-		inventory.PopulateInventory(instanceEntity, con)
+		inventory.PopulateInventory(instanceEntity, con, engineEdition)
 	}
 
 	// Metric collection
@@ -83,7 +91,7 @@ func main() {
 			log.Error("Error collecting metrics for databases: %s", err.Error())
 		}
 
-		metrics.PopulateInstanceMetrics(instanceEntity, con, args)
+		metrics.PopulateInstanceMetrics(instanceEntity, con, args, engineEdition)
 	}
 
 	// Close connection when done

--- a/src/testdata/nonEmptyMetrics.json.golden
+++ b/src/testdata/nonEmptyMetrics.json.golden
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "entity": {
+        "id_attributes": [],
+        "name": "test",
+        "type": "instance"
+      },
+      "events": [],
+      "inventory": {},
+      "metrics": [
+        {
+          "displayName": "test",
+          "entityName": "instance:test",
+          "event_type": "MssqlInstanceSample",
+          "host": "testhost",
+          "system.bufferPoolHitPercent": 95.5
+        }
+      ]
+    }
+  ],
+  "integration_version": "1.0.0",
+  "name": "test",
+  "protocol_version": "3"
+}


### PR DESCRIPTION
-  Skip Unsupported SQL Queries pattern (`sys.dm_os_process_memory`,`sys.master_files`,`exec sp_configure`,`sys.dm_os_sys_memory`,`sys.dm_os_volume_stats`) for Azure SQL Database 


### Test Results:

```shell
test@1234 bin %./nri-mssql -username="**"  -password="**" -port=1433 -hostname="**" -enable_buffer_metrics=true -enable_database_reserve_metrics=true -enable_disk_metrics_in_bytes -verbose=true
06:16:12.725108 [DEBUG] store file (/tmp/nr-integrations/com.newrelic.mssql-620af03b7337b72def7d45b9e21132e3.json) is older than 6m0s, skipping loading from disk.
[DEBUG] Running query: select COALESCE( @@SERVERNAME, SERVERPROPERTY('ServerName'), SERVERPROPERTY('MachineName')) as instance_name
[DEBUG] Running query: SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition;
[DEBUG] Skipping query 'EXEC sp_configure' for unsupported engine edition 5
[DEBUG] Running query: select name, value from sys.configurations
[DEBUG] Running query: select name as db_name from sys.databases where name not in ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
[DEBUG] Running query: select
                RTRIM(t1.instance_name) as db_name,
                t1.cntr_value as log_growth
                from (
      SELECT * FROM sys.dm_os_performance_counters WITH (NOLOCK)
      WHERE object_name = 'SQLServer:Databases'
        AND counter_name = 'Log Growths'
        AND RTRIM(instance_name) NOT IN ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
        AND instance_name NOT IN ('_Total', 'mssqlsystemresource', 'master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
    ) t1
    
[DEBUG] Running query: select
                DB_NAME(database_id) AS db_name,
                SUM(io_stall_write_ms) + SUM(num_of_writes) as io_stalls
                FROM sys.dm_io_virtual_file_stats(null,null)
    WHERE DB_NAME(database_id) NOT IN ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
                GROUP BY database_id
[DEBUG] Running query: SELECT DB_NAME(database_id) AS db_name, buffer_pool_size * (8*1024) AS buffer_pool_size
                FROM ( SELECT database_id, COUNT_BIG(*) AS buffer_pool_size FROM sys.dm_os_buffer_descriptors a WITH (NOLOCK)
                INNER JOIN sys.sysdatabases b WITH (NOLOCK) ON b.dbid=a.database_id 
                WHERE b.dbid in (SELECT dbid FROM sys.sysdatabases WITH (NOLOCK)
                WHERE name NOT IN ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
                UNION ALL SELECT 32767) GROUP BY database_id) a
[DEBUG] Running query: USE "testdb"
                ;WITH reserved_space(db_name, reserved_space_kb, reserved_space_not_used_kb)
                AS
                (
                SELECT
                        DB_NAME() AS db_name,
                        sum(a.total_pages)*8.0 reserved_space_kb,
                        sum(a.total_pages)*8.0 -sum(a.used_pages)*8.0 reserved_space_not_used_kb
                FROM sys.partitions p with (nolock)
                INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id
                )
                SELECT
                db_name as db_name,
                max(reserved_space_kb) * 1024 AS reserved_space,
                max(reserved_space_not_used_kb) * 1024 AS reserved_space_not_used
                FROM reserved_space
                GROUP BY db_name
[ERR] Unable to determine database name, {DataModel:{DBName:master} IOStalls:31186944}
[ERR] Encountered the following error: mssql: USE statement is not supported to switch between databases. Use a new connection to connect to a different database.. Running query 'USE "testdb"
                ;WITH reserved_space(db_name, reserved_space_kb, reserved_space_not_used_kb)
                AS
                (
                SELECT
                        DB_NAME() AS db_name,
                        sum(a.total_pages)*8.0 reserved_space_kb,
                        sum(a.total_pages)*8.0 -sum(a.used_pages)*8.0 reserved_space_not_used_kb
                FROM sys.partitions p with (nolock)
                INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id
                )
                SELECT
                db_name as db_name,
                max(reserved_space_kb) * 1024 AS reserved_space,
                max(reserved_space_not_used_kb) * 1024 AS reserved_space_not_used
                FROM reserved_space
                GROUP BY db_name'
[DEBUG] Running query: USE "AdventureWorks"
                ;WITH reserved_space(db_name, reserved_space_kb, reserved_space_not_used_kb)
                AS
                (
                SELECT
                        DB_NAME() AS db_name,
                        sum(a.total_pages)*8.0 reserved_space_kb,
                        sum(a.total_pages)*8.0 -sum(a.used_pages)*8.0 reserved_space_not_used_kb
                FROM sys.partitions p with (nolock)
                INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id
                )
                SELECT
                db_name as db_name,
                max(reserved_space_kb) * 1024 AS reserved_space,
                max(reserved_space_not_used_kb) * 1024 AS reserved_space_not_used
                FROM reserved_space
                GROUP BY db_name
[ERR] Encountered the following error: mssql: USE statement is not supported to switch between databases. Use a new connection to connect to a different database.. Running query 'USE "AdventureWorks"
                ;WITH reserved_space(db_name, reserved_space_kb, reserved_space_not_used_kb)
                AS
                (
                SELECT
                        DB_NAME() AS db_name,
                        sum(a.total_pages)*8.0 reserved_space_kb,
                        sum(a.total_pages)*8.0 -sum(a.used_pages)*8.0 reserved_space_not_used_kb
                FROM sys.partitions p with (nolock)
                INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id
                )
                SELECT
                db_name as db_name,
                max(reserved_space_kb) * 1024 AS reserved_space,
                max(reserved_space_not_used_kb) * 1024 AS reserved_space_not_used
                FROM reserved_space
                GROUP BY db_name'
[DEBUG] Running query: USE "ohai-test-db-1"
                ;WITH reserved_space(db_name, reserved_space_kb, reserved_space_not_used_kb)
                AS
                (
                SELECT
                        DB_NAME() AS db_name,
                        sum(a.total_pages)*8.0 reserved_space_kb,
                        sum(a.total_pages)*8.0 -sum(a.used_pages)*8.0 reserved_space_not_used_kb
                FROM sys.partitions p with (nolock)
                INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id
                )
                SELECT
                db_name as db_name,
                max(reserved_space_kb) * 1024 AS reserved_space,
                max(reserved_space_not_used_kb) * 1024 AS reserved_space_not_used
                FROM reserved_space
                GROUP BY db_name
[ERR] Encountered the following error: mssql: USE statement is not supported to switch between databases. Use a new connection to connect to a different database.. Running query 'USE "ohai-test-db-1"
                ;WITH reserved_space(db_name, reserved_space_kb, reserved_space_not_used_kb)
                AS
                (
                SELECT
                        DB_NAME() AS db_name,
                        sum(a.total_pages)*8.0 reserved_space_kb,
                        sum(a.total_pages)*8.0 -sum(a.used_pages)*8.0 reserved_space_not_used_kb
                FROM sys.partitions p with (nolock)
                INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id
                )
                SELECT
                db_name as db_name,
                max(reserved_space_kb) * 1024 AS reserved_space,
                max(reserved_space_not_used_kb) * 1024 AS reserved_space_not_used
                FROM reserved_space
                GROUP BY db_name'
[DEBUG] Running query: SELECT
                t1.cntr_value AS sql_compilations,
                t2.cntr_value AS sql_recompilations,
                t3.cntr_value AS user_connections,
                t4.cntr_value AS lock_wait_time_ms,
                t5.cntr_value AS page_splits_sec,
                t6.cntr_value AS checkpoint_pages_sec,
                t7.cntr_value AS deadlocks_sec,
                t8.cntr_value AS user_errors,
                t9.cntr_value AS kill_connection_errors,
                t10.cntr_value AS batch_request_sec,
                (t11.cntr_value * 1000.0) AS page_life_expectancy_ms,
                t12.cntr_value AS transactions_sec,
                t13.cntr_value AS forced_parameterizations_sec
                FROM 
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'SQL Compilations/sec') t1,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'SQL Re-Compilations/sec') t2,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'User Connections') t3,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Lock Wait Time (ms)' AND instance_name = '_Total') t4,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Page Splits/sec') t5,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Checkpoint pages/sec') t6,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Number of Deadlocks/sec' AND instance_name = '_Total') t7,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE object_name LIKE '%SQL Errors%' AND instance_name = 'User Errors') t8,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE object_name LIKE '%SQL Errors%' AND instance_name LIKE 'Kill Connection Errors%') t9,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Batch Requests/sec') t10,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Page life expectancy' AND object_name LIKE '%Manager%') t11,
                (SELECT Sum(cntr_value) AS cntr_value FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Transactions/sec') t12,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Forced Parameterizations/sec') t13
[DEBUG] Running query: SELECT (a.cntr_value * 1.0 / b.cntr_value) * 100.0 AS buffer_pool_hit_percent
                FROM sys.dm_os_performance_counters 
                a JOIN (SELECT cntr_value, OBJECT_NAME FROM sys.dm_os_performance_counters WHERE counter_name = 'Buffer cache hit ratio base') 
                b ON  a.OBJECT_NAME = b.OBJECT_NAME 
                WHERE a.counter_name = 'Buffer cache hit ratio'
[DEBUG] Running query: SELECT
                Sum(wait_time_ms) AS wait_time
                FROM sys.dm_os_wait_stats
                WHERE [wait_type] NOT IN (
                N'CLR_SEMAPHORE',    N'LAZYWRITER_SLEEP',
                N'RESOURCE_QUEUE',   N'SQLTRACE_BUFFER_FLUSH',
                N'SLEEP_TASK',       N'SLEEP_SYSTEMTASK',
                N'WAITFOR',          N'HADR_FILESTREAM_IOMGR_IOCOMPLETION',
                N'CHECKPOINT_QUEUE', N'REQUEST_FOR_DEADLOCK_SEARCH',
                N'XE_TIMER_EVENT',   N'XE_DISPATCHER_JOIN',
                N'LOGMGR_QUEUE',     N'FT_IFTS_SCHEDULER_IDLE_WAIT',
                N'BROKER_TASK_STOP', N'CLR_MANUAL_EVENT',
                N'CLR_AUTO_EVENT',   N'DISPATCHER_QUEUE_SEMAPHORE',
                N'TRACEWRITE',       N'XE_DISPATCHER_WAIT',
                N'BROKER_TO_FLUSH',  N'BROKER_EVENTHANDLER',
                N'FT_IFTSHC_MUTEX',  N'SQLTRACE_INCREMENTAL_FLUSH_SLEEP',
                N'DIRTY_PAGE_POLL',  N'SP_SERVER_DIAGNOSTICS_SLEEP')
[DEBUG] Running query: SELECT
                Max(CASE WHEN sessions.status = 'preconnect' THEN counts ELSE 0 END) AS preconnect,
                Max(CASE WHEN sessions.status = 'background' THEN counts ELSE 0 END) AS background,
                Max(CASE WHEN sessions.status = 'dormant' THEN counts ELSE 0 END) AS dormant,
                Max(CASE WHEN sessions.status = 'runnable' THEN counts ELSE 0 END) AS runnable,
                Max(CASE WHEN sessions.status = 'suspended' THEN counts ELSE 0 END) AS suspended,
                Max(CASE WHEN sessions.status = 'running' THEN counts ELSE 0 END) AS running,
                Max(CASE WHEN sessions.status = 'blocked' THEN counts ELSE 0 END) AS blocked,
                Max(CASE WHEN sessions.status = 'sleeping' THEN counts ELSE 0 END) AS sleeping
                FROM (SELECT status, Count(*) counts FROM (
                        SELECT CASE WHEN req.status IS NOT NULL THEN
                                CASE WHEN req.blocking_session_id <> 0 THEN 'blocked' ELSE req.status END
                          ELSE sess.status END status, req.blocking_session_id
                        FROM sys.dm_exec_sessions sess
                        LEFT JOIN sys.dm_exec_requests req
                        ON sess.session_id = req.session_id
                        WHERE sess.session_id > 50 ) statuses
                  GROUP BY status) sessions
[DEBUG] Running query: SELECT Sum(runnable_tasks_count) AS runnable_tasks_count
                FROM sys.dm_os_schedulers
                WHERE   scheduler_id < 255 AND [status] = 'VISIBLE ONLINE'
[DEBUG] Running query: SELECT Count(dbid) AS instance_active_connections FROM sys.sysprocesses WITH (nolock) WHERE dbid > 0
[DEBUG] Skipping query 'SELECT
                Max(sys_mem.total_physical_memory_kb * 1024.0) AS total_physical_memory,
                Max(sys_mem.available_physical_memory_kb * 1024.0) AS available_physical_memory,
                (Max(proc_mem.physical_memory_in_use_kb) / (Max(sys_mem.total_physical_memory_kb) * 1.0)) * 100 AS memory_utilization
                FROM sys.dm_os_process_memory proc_mem,
                  sys.dm_os_sys_memory sys_mem,
                  sys.dm_os_performance_counters perf_count WHERE object_name = 'SQLServer:Memory Manager'' for unsupported engine edition 5
[DEBUG] Running query:  SELECT
      Count_big(*) * (8*1024) AS instance_buffer_pool_size
      FROM sys.dm_os_buffer_descriptors WITH (nolock)
      WHERE database_id <> 32767 -- ResourceDB 
[DEBUG] Skipping query 'SELECT Sum(total_bytes) AS total_disk_space FROM (
                        SELECT DISTINCT
                        dovs.volume_mount_point,
                        dovs.available_bytes available_bytes,
                        dovs.total_bytes total_bytes
                        FROM sys.master_files mf WITH (nolock)
                        CROSS apply sys.Dm_os_volume_stats(mf.database_id, mf.file_id) dovs
                        ) drives' for unsupported engine edition 5
[DEBUG] Running query: SELECT wait_type, wait_time_ms AS wait_time, waiting_tasks_count
FROM sys.dm_os_wait_stats wait_stats
WHERE wait_time_ms != 0``` 