### PR TITLE
Modified database definition queries

### DIFF
--- a/src/metrics/database_metric_definitions.go
+++ b/src/metrics/database_metric_definitions.go
@@ -78,7 +78,7 @@ var specificDatabaseDefinitionsForAzureSQLDatabase = []*QueryDefinition{
 			    ON sd.physical_database_name = spc.instance_name
 			WHERE spc.counter_name = 'Log Growths'
 			    AND spc.object_name LIKE '%:Databases%'
-			    AND sd.name = DB_NAME()
+			    AND sd.database_id = DB_ID()
 		`,
 		dataModels: &[]struct {
 			database.DataModel


### PR DESCRIPTION
The definition queries were modified to add support for Azure SQL Database.
Since we connect to each database individually and execute the queries, we do not need the `USE` statements or `GROUP BY` statements.