### PR TITLE
feat: create new connections to each database in case of azure sql database

### DIFF
--- a/src/connection/sql_connection.go
+++ b/src/connection/sql_connection.go
@@ -88,6 +88,7 @@ func CreateConnectionURL(args *args.ArgumentList, dbName string) string {
 	query.Add("connection timeout", args.Timeout)
 	if dbName != "" {
 		query.Add("database", dbName)
+		log.Debug("using database name : %s as a query parameter in the connection url", dbName)
 	}
 
 	if args.ExtraConnectionURLArgs != "" {

--- a/src/connection/sql_connection_test.go
+++ b/src/connection/sql_connection_test.go
@@ -54,9 +54,10 @@ func Test_SQLConnection_Query(t *testing.T) {
 
 func Test_createConnectionURL(t *testing.T) {
 	testCases := []struct {
-		name string
-		arg  *args.ArgumentList
-		want string
+		name   string
+		arg    *args.ArgumentList
+		dbName string
+		want   string
 	}{
 		{
 			"Port No SSL",
@@ -68,6 +69,7 @@ func Test_createConnectionURL(t *testing.T) {
 				Port:      "1443",
 				Timeout:   "30",
 			},
+			"",
 			"sqlserver://user:pass@localhost:1443?connection+timeout=30&dial+timeout=30",
 		},
 		{
@@ -80,6 +82,7 @@ func Test_createConnectionURL(t *testing.T) {
 				Instance:  "SQLExpress",
 				Timeout:   "30",
 			},
+			"",
 			"sqlserver://user:pass@localhost/SQLExpress?connection+timeout=30&dial+timeout=30",
 		},
 		{
@@ -93,6 +96,7 @@ func Test_createConnectionURL(t *testing.T) {
 				Instance:               "SQLExpress",
 				Timeout:                "30",
 			},
+			"",
 			"sqlserver://user:pass@localhost/SQLExpress?TrustServerCertificate=true&connection+timeout=30&dial+timeout=30&encrypt=true",
 		},
 		{
@@ -107,6 +111,7 @@ func Test_createConnectionURL(t *testing.T) {
 				Instance:               "SQLExpress",
 				Timeout:                "30",
 			},
+			"",
 			"sqlserver://user:pass@localhost/SQLExpress?TrustServerCertificate=false&certificate=file.ca&connection+timeout=30&dial+timeout=30&encrypt=true",
 		},
 		{
@@ -120,12 +125,26 @@ func Test_createConnectionURL(t *testing.T) {
 				Timeout:                "30",
 				ExtraConnectionURLArgs: "applicationIntent=true",
 			},
+			"",
 			"sqlserver://user:pass@localhost:1443?applicationIntent=true&connection+timeout=30&dial+timeout=30",
+		},
+		{
+			"Database Name",
+			&args.ArgumentList{
+				Username:  "user",
+				Password:  "pass",
+				Hostname:  "localhost",
+				EnableSSL: false,
+				Port:      "1443",
+				Timeout:   "30",
+			},
+			"test-db",
+			"sqlserver://user:pass@localhost:1443?connection+timeout=30&database=test-db&dial+timeout=30",
 		},
 	}
 
 	for _, tc := range testCases {
-		if out := CreateConnectionURL(tc.arg); out != tc.want {
+		if out := CreateConnectionURL(tc.arg, tc.dbName); out != tc.want {
 			t.Errorf("Test Case %s Failed: Expected '%s' got '%s'", tc.name, tc.want, out)
 		}
 	}

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -40,6 +40,8 @@ var (
 	errMissingMetricNameCustomQuery  = errors.New("missing 'metric_name' for custom query")
 )
 
+const maxConcurrentWorkers = 10
+
 // PopulateInstanceMetrics creates instance-level metrics
 //
 //nolint:gocyclo
@@ -323,8 +325,20 @@ func metricFromTargetColumns(metricValue, metricName, metricType string, query c
 	return &customQueryMetricValue{value: metricValue, sourceType: sourceType}, nil
 }
 
+type databaseMetricsProcessor func(*integration.Integration, string, *connection.SQLConnection, args.ArgumentList, database.DBMetricSetLookup, int, chan<- interface{})
+
+// returns a processor function based on the engine edition
+func getProcessorForEngine(engineEdition int) databaseMetricsProcessor {
+	switch engineEdition {
+	case database.AzureSQLDatabaseEngineEditionNumber:
+		return processAzureSQLDatabaseMetrics
+	default:
+		return processDefaultDBMetrics
+	}
+}
+
 // PopulateDatabaseMetrics collects per-database metrics
-func PopulateDatabaseMetrics(i *integration.Integration, instanceName string, connection *connection.SQLConnection, arguments args.ArgumentList) error {
+func PopulateDatabaseMetrics(i *integration.Integration, instanceName string, connection *connection.SQLConnection, arguments args.ArgumentList, engineEdition int) error {
 	// create database entities
 	dbEntities, err := database.CreateDatabaseEntities(i, connection, instanceName)
 	if err != nil {
@@ -340,6 +354,17 @@ func PopulateDatabaseMetrics(i *integration.Integration, instanceName string, co
 	wg.Add(1)
 	go dbMetricPopulator(dbSetLookup, modelChan, &wg)
 
+	processor := getProcessorForEngine(engineEdition)
+	processor(i, instanceName, connection, arguments, dbSetLookup, engineEdition, modelChan)
+
+	close(modelChan)
+	wg.Wait()
+
+	return nil
+}
+
+// processDefaultDBMetrics handles metric collection for a standard SQL Server instance.
+func processDefaultDBMetrics(i *integration.Integration, instanceName string, connection *connection.SQLConnection, arguments args.ArgumentList, dbSetLookup database.DBMetricSetLookup, _ int, modelChan chan<- interface{}) {
 	// run queries that are not specific to a database
 	processGeneralDBDefinitions(connection, modelChan)
 
@@ -352,11 +377,58 @@ func PopulateDatabaseMetrics(i *integration.Integration, instanceName string, co
 	if arguments.EnableDatabaseReserveMetrics {
 		processSpecificDBDefinitions(connection, dbSetLookup.GetDBNames(), modelChan)
 	}
+}
 
-	close(modelChan)
-	wg.Wait()
+func processSingleAzureDB(
+	wg *sync.WaitGroup,
+	dbChan chan struct{},
+	dbName string,
+	arguments args.ArgumentList,
+	engineEdition int,
+	modelChan chan<- interface{},
+) {
+	defer wg.Done()
+	defer func() { <-dbChan }()
 
-	return nil
+	con, err := connection.CreateDatabaseConnection(&arguments, dbName)
+	if err != nil {
+		log.Error("Error creating connection to SQL Server: %s", err.Error())
+		log.Warn("Skipping populating db metrics for database : %s", dbName)
+		return
+	}
+	defer con.Close()
+
+	processDBDefinitons(con, getDatabaseDefinitions(engineEdition), modelChan)
+
+	if arguments.EnableBufferMetrics {
+		processDBDefinitons(con, getDatabaseBufferDefinitions(engineEdition), modelChan)
+	}
+
+	if arguments.EnableDatabaseReserveMetrics {
+		processDBDefinitons(con, getSpecificDatabaseDefinitions(engineEdition), modelChan)
+	}
+}
+
+// processAzureSQLDatabaseMetrics handles metric collection for Azure SQL Database concurrently.
+// It dispatches the work of processing each database to a worker goroutine.
+func processAzureSQLDatabaseMetrics(i *integration.Integration, instanceName string, _ *connection.SQLConnection, arguments args.ArgumentList, dbSetLookup database.DBMetricSetLookup, engineEdition int, modelChan chan<- interface{}) {
+	databaseNames := dbSetLookup.GetDBNames()
+
+	dbChan := make(chan struct{}, maxConcurrentWorkers)
+	var waitGroup sync.WaitGroup
+
+	for _, dbName := range databaseNames {
+		waitGroup.Add(1)
+		dbChan <- struct{}{}
+		go processSingleAzureDB(&waitGroup, dbChan, dbName, arguments, engineEdition, modelChan)
+	}
+	waitGroup.Wait()
+}
+
+func processDBDefinitons(con *connection.SQLConnection, definitions []*QueryDefinition, modelChan chan<- interface{}) {
+	for _, queryDef := range definitions {
+		makeDBQuery(con, queryDef.GetQuery(), queryDef.GetDataModels(), modelChan)
+	}
 }
 
 func processGeneralDBDefinitions(con *connection.SQLConnection, modelChan chan<- interface{}) {

--- a/src/mssql.go
+++ b/src/mssql.go
@@ -87,7 +87,7 @@ func main() {
 
 	// Metric collection
 	if args.HasMetrics() {
-		if err := metrics.PopulateDatabaseMetrics(i, instanceEntity.Metadata.Name, con, args); err != nil {
+		if err := metrics.PopulateDatabaseMetrics(i, instanceEntity.Metadata.Name, con, args, engineEdition); err != nil {
 			log.Error("Error collecting metrics for databases: %s", err.Error())
 		}
 

--- a/src/testdata/azureSQLDatabaseMetrics.json.golden
+++ b/src/testdata/azureSQLDatabaseMetrics.json.golden
@@ -36,7 +36,10 @@
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
+                    "io.stallInMilliseconds": 0,
                     "log.transactionGrowth": 0,
+                    "pageFileTotal": 0,
+                    "pageFileAvailable": 0,
                     "reportingEndpoint": "testhost"
                 }
             ],
@@ -66,7 +69,10 @@
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
+                    "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
+                    "pageFileTotal": 1,
+                    "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"
                 }
             ],

--- a/src/testdata/partialAzureSQLDatabaseMetrics.json.golden
+++ b/src/testdata/partialAzureSQLDatabaseMetrics.json.golden
@@ -30,13 +30,11 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 0,
                     "displayName": "db-1",
                     "entityName": "ms-database:db-1",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "log.transactionGrowth": 0,
                     "reportingEndpoint": "testhost"
                 }
             ],
@@ -60,13 +58,15 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 1,
                     "displayName": "db-2",
                     "entityName": "ms-database:db-2",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
+                    "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
+                    "pageFileTotal": 1,
+                    "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"
                 }
             ],


### PR DESCRIPTION
Changes in this PR - 

When instrumenting an Azure SQL Database type service.
- Populate database metrics using queries that are specific to Azure SQL Database.
- Create new connections to each database for retrieving database metrics.
- Add unit tests for the same.

Below are the list of database metrics that are retrieved using Azure SQL Database specific queries.

1. `log.transactionGrowth`
2. `io.stallInMilliseconds`
3. `bufferpool.sizePerDatabaseInBytes`
4. `pageFileTotal`
5. `pageFileAvailable`

<details><summary>Testing Details : </summary>
<p>

```shell
root@sairaj-mssql-test-2:/home/sairaj/nri-mssql/bin# ./nri-mssql -username="newrelic"  -password="*****" -port=1433 -hostname="test.database.windows.net" -enable_buffer_metrics=true -enable_database_reserve_metrics=true -enable_disk_metrics_in_bytes -verbose=true
07:44:33.778077 [DEBUG] store file (/tmp/nr-integrations/com.newrelic.mssql-620af03b7337b72def7d45b9e21132e3.json) is older than 6m0s, skipping loading from disk.
[DEBUG] Running query: select COALESCE( @@SERVERNAME, SERVERPROPERTY('ServerName'), SERVERPROPERTY('MachineName')) as instance_name
[DEBUG] Running query: SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition;
[DEBUG] Skipping query 'EXEC sp_configure' for unsupported engine edition 5
[DEBUG] Running query: select name, value from sys.configurations
[DEBUG] Running query: select name as db_name from sys.databases where name not in ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
[DEBUG] Running query: 
                        SELECT 
                            sd.name AS db_name,
                            spc.cntr_value AS log_growth
                        FROM sys.dm_os_performance_counters spc
                        INNER JOIN sys.databases sd 
                            ON sd.physical_database_name = spc.instance_name
                        WHERE spc.counter_name = 'Log Growths'
                            AND spc.object_name LIKE '%:Databases%'
                            AND sd.database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                            DB_NAME() AS db_name,
                            SUM(io_stall) AS io_stalls
                        FROM sys.dm_io_virtual_file_stats(NULL, NULL)
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT 
                            DB_NAME() AS db_name, 
                            COUNT_BIG(*) * (8 * 1024) AS buffer_pool_size
                        FROM sys.dm_os_buffer_descriptors WITH (NOLOCK) 
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                                DB_NAME() AS db_name,
                                sum(a.total_pages) * 8.0 * 1024 AS reserved_space,
                                (sum(a.total_pages)*8.0 - sum(a.used_pages)*8.0) * 1024 AS reserved_space_not_used
                        FROM sys.partitions p with (nolock)
                        INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                        LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id

[DEBUG] Running query: 
                        SELECT 
                            sd.name AS db_name,
                            spc.cntr_value AS log_growth
                        FROM sys.dm_os_performance_counters spc
                        INNER JOIN sys.databases sd 
                            ON sd.physical_database_name = spc.instance_name
                        WHERE spc.counter_name = 'Log Growths'
                            AND spc.object_name LIKE '%:Databases%'
                            AND sd.database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                            DB_NAME() AS db_name,
                            SUM(io_stall) AS io_stalls
                        FROM sys.dm_io_virtual_file_stats(NULL, NULL)
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT 
                            DB_NAME() AS db_name, 
                            COUNT_BIG(*) * (8 * 1024) AS buffer_pool_size
                        FROM sys.dm_os_buffer_descriptors WITH (NOLOCK) 
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                                DB_NAME() AS db_name,
                                sum(a.total_pages) * 8.0 * 1024 AS reserved_space,
                                (sum(a.total_pages)*8.0 - sum(a.used_pages)*8.0) * 1024 AS reserved_space_not_used
                        FROM sys.partitions p with (nolock)
                        INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                        LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id

[DEBUG] Running query: 
                        SELECT 
                            sd.name AS db_name,
                            spc.cntr_value AS log_growth
                        FROM sys.dm_os_performance_counters spc
                        INNER JOIN sys.databases sd 
                            ON sd.physical_database_name = spc.instance_name
                        WHERE spc.counter_name = 'Log Growths'
                            AND spc.object_name LIKE '%:Databases%'
                            AND sd.database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                            DB_NAME() AS db_name,
                            SUM(io_stall) AS io_stalls
                        FROM sys.dm_io_virtual_file_stats(NULL, NULL)
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT 
                            DB_NAME() AS db_name, 
                            COUNT_BIG(*) * (8 * 1024) AS buffer_pool_size
                        FROM sys.dm_os_buffer_descriptors WITH (NOLOCK) 
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                                DB_NAME() AS db_name,
                                sum(a.total_pages) * 8.0 * 1024 AS reserved_space,
                                (sum(a.total_pages)*8.0 - sum(a.used_pages)*8.0) * 1024 AS reserved_space_not_used
                        FROM sys.partitions p with (nolock)
                        INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                        LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id

[DEBUG] Running query: SELECT
                t1.cntr_value AS sql_compilations,
                t2.cntr_value AS sql_recompilations,
                t3.cntr_value AS user_connections,
                t4.cntr_value AS lock_wait_time_ms,
                t5.cntr_value AS page_splits_sec,
                t6.cntr_value AS checkpoint_pages_sec,
                t7.cntr_value AS deadlocks_sec,
                t8.cntr_value AS user_errors,
                t9.cntr_value AS kill_connection_errors,
                t10.cntr_value AS batch_request_sec,
                (t11.cntr_value * 1000.0) AS page_life_expectancy_ms,
                t12.cntr_value AS transactions_sec,
                t13.cntr_value AS forced_parameterizations_sec
                FROM 
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'SQL Compilations/sec') t1,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'SQL Re-Compilations/sec') t2,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'User Connections') t3,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Lock Wait Time (ms)' AND instance_name = '_Total') t4,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Page Splits/sec') t5,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Checkpoint pages/sec') t6,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Number of Deadlocks/sec' AND instance_name = '_Total') t7,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE object_name LIKE '%SQL Errors%' AND instance_name = 'User Errors') t8,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE object_name LIKE '%SQL Errors%' AND instance_name LIKE 'Kill Connection Errors%') t9,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Batch Requests/sec') t10,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Page life expectancy' AND object_name LIKE '%Manager%') t11,
                (SELECT Sum(cntr_value) AS cntr_value FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Transactions/sec') t12,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Forced Parameterizations/sec') t13
[DEBUG] Running query: SELECT (a.cntr_value * 1.0 / b.cntr_value) * 100.0 AS buffer_pool_hit_percent
                FROM sys.dm_os_performance_counters 
                a JOIN (SELECT cntr_value, OBJECT_NAME FROM sys.dm_os_performance_counters WHERE counter_name = 'Buffer cache hit ratio base') 
                b ON  a.OBJECT_NAME = b.OBJECT_NAME 
                WHERE a.counter_name = 'Buffer cache hit ratio'
[DEBUG] Running query: SELECT
                Sum(wait_time_ms) AS wait_time
                FROM sys.dm_os_wait_stats
                WHERE [wait_type] NOT IN (
                N'CLR_SEMAPHORE',    N'LAZYWRITER_SLEEP',
                N'RESOURCE_QUEUE',   N'SQLTRACE_BUFFER_FLUSH',
                N'SLEEP_TASK',       N'SLEEP_SYSTEMTASK',
                N'WAITFOR',          N'HADR_FILESTREAM_IOMGR_IOCOMPLETION',
                N'CHECKPOINT_QUEUE', N'REQUEST_FOR_DEADLOCK_SEARCH',
                N'XE_TIMER_EVENT',   N'XE_DISPATCHER_JOIN',
                N'LOGMGR_QUEUE',     N'FT_IFTS_SCHEDULER_IDLE_WAIT',
                N'BROKER_TASK_STOP', N'CLR_MANUAL_EVENT',
                N'CLR_AUTO_EVENT',   N'DISPATCHER_QUEUE_SEMAPHORE',
                N'TRACEWRITE',       N'XE_DISPATCHER_WAIT',
                N'BROKER_TO_FLUSH',  N'BROKER_EVENTHANDLER',
                N'FT_IFTSHC_MUTEX',  N'SQLTRACE_INCREMENTAL_FLUSH_SLEEP',
                N'DIRTY_PAGE_POLL',  N'SP_SERVER_DIAGNOSTICS_SLEEP')
[DEBUG] Running query: SELECT
                Max(CASE WHEN sessions.status = 'preconnect' THEN counts ELSE 0 END) AS preconnect,
                Max(CASE WHEN sessions.status = 'background' THEN counts ELSE 0 END) AS background,
                Max(CASE WHEN sessions.status = 'dormant' THEN counts ELSE 0 END) AS dormant,
                Max(CASE WHEN sessions.status = 'runnable' THEN counts ELSE 0 END) AS runnable,
                Max(CASE WHEN sessions.status = 'suspended' THEN counts ELSE 0 END) AS suspended,
                Max(CASE WHEN sessions.status = 'running' THEN counts ELSE 0 END) AS running,
                Max(CASE WHEN sessions.status = 'blocked' THEN counts ELSE 0 END) AS blocked,
                Max(CASE WHEN sessions.status = 'sleeping' THEN counts ELSE 0 END) AS sleeping
                FROM (SELECT status, Count(*) counts FROM (
                        SELECT CASE WHEN req.status IS NOT NULL THEN
                                CASE WHEN req.blocking_session_id <> 0 THEN 'blocked' ELSE req.status END
                          ELSE sess.status END status, req.blocking_session_id
                        FROM sys.dm_exec_sessions sess
                        LEFT JOIN sys.dm_exec_requests req
                        ON sess.session_id = req.session_id
                        WHERE sess.session_id > 50 ) statuses
                  GROUP BY status) sessions
[DEBUG] Running query: SELECT Sum(runnable_tasks_count) AS runnable_tasks_count
                FROM sys.dm_os_schedulers
                WHERE   scheduler_id < 255 AND [status] = 'VISIBLE ONLINE'
[DEBUG] Running query: SELECT Count(dbid) AS instance_active_connections FROM sys.sysprocesses WITH (nolock) WHERE dbid > 0
[DEBUG] Skipping query 'SELECT
                Max(sys_mem.total_physical_memory_kb * 1024.0) AS total_physical_memory,
                Max(sys_mem.available_physical_memory_kb * 1024.0) AS available_physical_memory,
                (Max(proc_mem.physical_memory_in_use_kb) / (Max(sys_mem.total_physical_memory_kb) * 1.0)) * 100 AS memory_utilization
                FROM sys.dm_os_process_memory proc_mem,
                  sys.dm_os_sys_memory sys_mem,
                  sys.dm_os_performance_counters perf_count WHERE object_name = 'SQLServer:Memory Manager'' for unsupported engine edition 5
[DEBUG] Running query:  SELECT
      Count_big(*) * (8*1024) AS instance_buffer_pool_size
      FROM sys.dm_os_buffer_descriptors WITH (nolock)
      WHERE database_id <> 32767 -- ResourceDB 
[DEBUG] Skipping query 'SELECT Sum(total_bytes) AS total_disk_space FROM (
                        SELECT DISTINCT
                        dovs.volume_mount_point,
                        dovs.available_bytes available_bytes,
                        dovs.total_bytes total_bytes
                        FROM sys.master_files mf WITH (nolock)
                        CROSS apply sys.Dm_os_volume_stats(mf.database_id, mf.file_id) dovs
                        ) drives' for unsupported engine edition 5
[DEBUG] Running query: SELECT wait_type, wait_time_ms AS wait_time, waiting_tasks_count
FROM sys.dm_os_wait_stats wait_stats
WHERE wait_time_ms != 0
output.json was printed here.
root@sairaj-mssql-test-2:/home/sairaj/nri-mssql/bin# 
``` 

</p>
</details> 

[output.json](https://github.com/user-attachments/files/20652802/output.json)