### PR TITLE
feat: populate memory, disk metrics and inventory for azure sql database

### DIFF
--- a/spec.csv
+++ b/spec.csv
@@ -13,9 +13,10 @@ MS SQL,stats.userErrorsPerSecond,Rate,true,Number of user errors per second sinc
 MS SQL,stats.killConnectionErrorsPerSecond,Rate,true,Number of kill connection errors per second since last restart
 MS SQL,log.transactionGrowth,Gauge,true,Total number of times the transaction log for the database has been expanded last restart
 MS SQL,iO.stallInMiliseconds,Gauge,true,Wait time of stall since last restart in Miliseconds
-MS SQL,memoryUtilization,Gauge,true,Percentage of Memory Utilization
-MS SQL,memoryTotal,Gauge,true,Total Physical memory in Bytes
-MS SQL,memoryAvailable,Gauge,true,Available physical memory in Bytes
+MS SQL,maxDiskSizeInBytes,Gauge,true,Maximum database size in bytes. Applies to: Azure SQL Database.
+MS SQL,memoryUtilization,Gauge,true,Percentage of Memory Utilization. Note: This metric is populated per database in case of Azure SQL Database.
+MS SQL,memoryTotal,Gauge,true,Total Physical memory in Bytes. Note: This metric is populated per database in case of Azure SQL Database.
+MS SQL,memoryAvailable,Gauge,true,Available physical memory in Bytes. Note: This metric is populated per database in case of Azure SQL Database.
 MS SQL,pageFileTotal,Gauge,true,Total Page File in Bytes
 MS SQL,pageFileAvailable,Gauge,true,Availbe page file in Bytes
 MS SQL,system.bufferPoolHit,Gauge,true,The percentage of buffer pools hits on the instance

--- a/src/inventory/inventory.go
+++ b/src/inventory/inventory.go
@@ -4,13 +4,14 @@ package inventory
 import (
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
-	"github.com/newrelic/nri-mssql/src/common"
 	"github.com/newrelic/nri-mssql/src/connection"
+	"github.com/newrelic/nri-mssql/src/metrics"
 )
 
 const (
-	spConfigQuery  = "EXEC sp_configure"
-	sysConfigQuery = "select name, value from sys.configurations"
+	spConfigQuery                    = "EXEC sp_configure"
+	sysConfigQuery                   = "select name, value from sys.configurations"
+	spConfigQueryForAzureSQLDatabase = "SELECT name, value_in_use FROM sys.configurations"
 )
 
 // SPConfigRow represents a row in the table returned by spConfigQuery
@@ -22,11 +23,18 @@ type SPConfigRow struct {
 	RunValue    int    `db:"run_value"`
 }
 
+type SPConfigRowForAzureSQLDatabase struct {
+	Name     string `db:"name"`
+	RunValue int    `db:"value_in_use"`
+}
+
 // ConfigQueryRow represents a row in the table returned by sysConfigQuery
 type ConfigQueryRow struct {
 	Name  string `db:"name"`
 	Value int    `db:"value"`
 }
+
+type spConfigItemsProcessor func(instanceEntity *integration.Entity, connection *connection.SQLConnection) error
 
 // PopulateInventory gathers inventory data for the SQL Server instance and populates it into entity
 func PopulateInventory(instanceEntity *integration.Entity, connection *connection.SQLConnection, engineEdition int) {
@@ -41,21 +49,10 @@ func PopulateInventory(instanceEntity *integration.Entity, connection *connectio
 
 // populateSPConfigItems collects inventory items for sp_configure procedure
 func populateSPConfigItems(instanceEntity *integration.Entity, connection *connection.SQLConnection, engineEdition int) error {
-	if common.ShouldSkipQueryForEngineEdition(engineEdition, spConfigQuery) {
-		log.Debug("Skipping query '%s' for unsupported engine edition %d", spConfigQuery, engineEdition)
-
-		return nil
-	}
-	configRows := make([]*SPConfigRow, 0)
-	if err := connection.Query(&configRows, spConfigQuery); err != nil {
+	processor := spConfigProcessorFunctionSet.Select(engineEdition)
+	if err := processor(instanceEntity, connection); err != nil {
 		return err
 	}
-
-	for _, row := range configRows {
-		itemName := row.Name + "/run_value"
-		setItemOrLog(instanceEntity, itemName, row.RunValue)
-	}
-
 	return nil
 }
 
@@ -80,4 +77,36 @@ func setItemOrLog(instanceEntity *integration.Entity, key string, value interfac
 	if err := instanceEntity.SetInventoryItem(key, "value", value); err != nil {
 		log.Error("Error setting inventory item '%s': %s", key, err.Error())
 	}
+}
+
+// Bucket for processor functions
+var spConfigProcessorFunctionSet = metrics.EngineSet[spConfigItemsProcessor]{
+	Default:          processSPConfigItems,
+	AzureSQLDatabase: processAzureSQLDatabaseSPConfigItems,
+}
+
+func processSPConfigItems(instanceEntity *integration.Entity, connection *connection.SQLConnection) error {
+	configRows := make([]*SPConfigRow, 0)
+	if err := connection.Query(&configRows, spConfigQuery); err != nil {
+		return err
+	}
+
+	for _, row := range configRows {
+		itemName := row.Name + "/run_value"
+		setItemOrLog(instanceEntity, itemName, row.RunValue)
+	}
+	return nil
+}
+
+func processAzureSQLDatabaseSPConfigItems(instanceEntity *integration.Entity, connection *connection.SQLConnection) error {
+	configRows := make([]*SPConfigRowForAzureSQLDatabase, 0)
+	if err := connection.Query(&configRows, spConfigQueryForAzureSQLDatabase); err != nil {
+		return err
+	}
+
+	for _, row := range configRows {
+		itemName := row.Name + "/run_value"
+		setItemOrLog(instanceEntity, itemName, row.RunValue)
+	}
+	return nil
 }

--- a/src/inventory/inventory_test.go
+++ b/src/inventory/inventory_test.go
@@ -13,6 +13,8 @@ import (
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
+var errForTesting = errors.New("error")
+
 // CreateMockSQL creates a Test SQLConnection.
 func CreateMockSQL(t *testing.T) (con *connection.SQLConnection, mock sqlmock.Sqlmock) {
 	mockDB, mock, err := sqlmock.New()
@@ -28,19 +30,62 @@ func CreateMockSQL(t *testing.T) (con *connection.SQLConnection, mock sqlmock.Sq
 	return
 }
 
+type InventoryTestCase struct {
+	name               string
+	spConfigSetup      func(mock sqlmock.Sqlmock) // Function to mock sp_configure query
+	sysConfigSetup     func(mock sqlmock.Sqlmock) // Function to mock sys.configurations query
+	expectedInventory  map[string]inventory.Item  // Expected inventory items
+	engineEditionValue int                        // Engine edition value
+}
+
+func runTestPopulateInventory(t *testing.T, tt InventoryTestCase) {
+	t.Run(tt.name, func(t *testing.T) {
+		i, err := integration.New("test", "1.0.0")
+		if err != nil {
+			t.Fatalf("Unexpected error %s", err.Error())
+		}
+
+		e, err := i.Entity("test", "instance")
+		if err != nil {
+			t.Fatalf("Unexpected error %s", err.Error())
+		}
+
+		conn, mock := CreateMockSQL(t)
+
+		// Setup mocks
+		tt.spConfigSetup(mock)
+		tt.sysConfigSetup(mock)
+
+		PopulateInventory(e, conn, tt.engineEditionValue)
+
+		// Validate inventory
+		equal := true
+		for k, expectedV := range tt.expectedInventory {
+			v, ok := e.Inventory.Item(k)
+			if !ok {
+				equal = false
+				break
+			}
+
+			if !reflect.DeepEqual(expectedV, v) {
+				equal = false
+				break
+			}
+		}
+
+		if !equal {
+			t.Errorf("Expected %+v got %+v", tt.expectedInventory, e.Inventory.Items())
+		}
+	})
+}
+
 func Test_populateInventory(t *testing.T) {
 	// Uncomment the following line to enable logging during tests
 	// log.SetupLogging(true)
 	// defer log.SetupLogging(false)
-	tests := []struct {
-		name               string
-		spConfigSetup      func(mock sqlmock.Sqlmock) // Function to mock sp_configure query
-		sysConfigSetup     func(mock sqlmock.Sqlmock) // Function to mock sys.configurations query
-		expectedInventory  map[string]inventory.Item  // Expected inventory items
-		engineEditionValue int                        // Engine edition value
-	}{
+	tests := []InventoryTestCase{
 		{
-			name: "Successful inventory population",
+			name: "Successful inventory population for regular sql server",
 			spConfigSetup: func(mock sqlmock.Sqlmock) {
 				spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
 					AddRow("allow polybase export", 0, 1, 0, 0).
@@ -62,9 +107,31 @@ func Test_populateInventory(t *testing.T) {
 			engineEditionValue: 3,
 		},
 		{
-			name: "Engine edition 5: Only sys.configurations items collected",
+			name: "Successful inventory collection for azure sql database",
 			spConfigSetup: func(mock sqlmock.Sqlmock) {
-				// No rows/queries expected for sp_configure since it should be skipped
+				spConfigRows := sqlmock.NewRows([]string{"name", "value_in_use"}).
+					AddRow("allow polybase export", 2).
+					AddRow("allow updates", 2)
+				mock.ExpectQuery(spConfigQueryForAzureSQLDatabase).WillReturnRows(spConfigRows)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
+					AddRow("allow polybase export", 1).
+					AddRow("allow updates", 1)
+				mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/run_value":    {"value": 2},
+				"allow updates/run_value":            {"value": 2},
+				"allow polybase export/config_value": {"value": 1},
+				"allow updates/config_value":         {"value": 1},
+			},
+			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber, // Azure SQL Database
+		},
+		{
+			name: "Error spConfig and success sysConfig for regular sql server",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(spConfigQuery).WillReturnError(errForTesting)
 			},
 			sysConfigSetup: func(mock sqlmock.Sqlmock) {
 				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
@@ -76,156 +143,62 @@ func Test_populateInventory(t *testing.T) {
 				"allow polybase export/config_value": {"value": 1},
 				"allow updates/config_value":         {"value": 1},
 			},
+			engineEditionValue: 3,
+		},
+		{
+			name: "Error spConfig and success sysConfig for azure sql database",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(spConfigQueryForAzureSQLDatabase).WillReturnError(errForTesting)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
+					AddRow("allow polybase export", 1).
+					AddRow("allow updates", 1)
+				mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/config_value": {"value": 1},
+				"allow updates/config_value":         {"value": 1},
+			},
+			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber,
+		},
+		{
+			name: "Error sysConfig and success spConfig for regular sql server",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
+					AddRow("allow polybase export", 0, 1, 0, 0).
+					AddRow("allow updates", 0, 1, 0, 0)
+				mock.ExpectQuery(spConfigQuery).WillReturnRows(spConfigRows)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(sysConfigQuery).WillReturnError(errForTesting)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/run_value": {"value": 0},
+				"allow updates/run_value":         {"value": 0},
+			},
+			engineEditionValue: 3,
+		},
+		{
+			name: "Error sysConfig and success spConfig for azure sql database",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				spConfigRows := sqlmock.NewRows([]string{"name", "value_in_use"}).
+					AddRow("allow polybase export", 2).
+					AddRow("allow updates", 2)
+				mock.ExpectQuery(spConfigQueryForAzureSQLDatabase).WillReturnRows(spConfigRows)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(sysConfigQuery).WillReturnError(errForTesting)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/run_value": {"value": 2},
+				"allow updates/run_value":         {"value": 2},
+			},
 			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber, // Azure SQL Database
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			i, err := integration.New("test", "1.0.0")
-			if err != nil {
-				t.Fatalf("Unexpected error %s", err.Error())
-			}
-
-			e, err := i.Entity("test", "instance")
-			if err != nil {
-				t.Fatalf("Unexpected error %s", err.Error())
-			}
-
-			conn, mock := CreateMockSQL(t)
-
-			// Setup mocks
-			tt.spConfigSetup(mock)
-			tt.sysConfigSetup(mock)
-
-			PopulateInventory(e, conn, tt.engineEditionValue)
-
-			// Validate inventory
-			equal := true
-			for k, expectedV := range tt.expectedInventory {
-				v, ok := e.Inventory.Item(k)
-				if !ok {
-					equal = false
-					break
-				}
-
-				if !reflect.DeepEqual(expectedV, v) {
-					equal = false
-					break
-				}
-			}
-
-			if !equal {
-				t.Errorf("Expected %+v got %+v", tt.expectedInventory, e.Inventory.Items())
-			}
-		})
-	}
-}
-
-func Test_populateInventory_SPConfigError(t *testing.T) {
-	i, err := integration.New("test", "1.0.0")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
-
-	e, err := i.Entity("test", "instance")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
-
-	conn, mock := CreateMockSQL(t)
-
-	engineEdition := 3
-
-	// SPConfig expect
-	mock.ExpectQuery(spConfigQuery).WillReturnError(errors.New("error"))
-
-	// sys.configurations expect
-	sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
-		AddRow("allow polybase export", 1).
-		AddRow("allow updates", 1)
-	mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
-
-	PopulateInventory(e, conn, engineEdition)
-
-	// expected inventory.Items map to be set
-	expected := map[string]inventory.Item{
-		"allow polybase export/config_value": {"value": 1},
-		"allow updates/config_value":         {"value": 1},
-	}
-
-	// reflect.DeepEqual did not work on comparing Items maps so did a manual comparison
-	equal := true
-	for k, expectedV := range expected {
-		v, ok := e.Inventory.Item(k)
-		if !ok {
-			equal = false
-			break
-		}
-
-		if !reflect.DeepEqual(expectedV, v) {
-			equal = false
-			break
-		}
-	}
-
-	if !equal {
-		t.Errorf("Expected %+v got %+v", expected, e.Inventory.Items())
-	}
-}
-
-func Test_populateInventory_SysConfigError(t *testing.T) {
-	i, err := integration.New("test", "1.0.0")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
-
-	e, err := i.Entity("test", "instance")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
-
-	conn, mock := CreateMockSQL(t)
-
-	engineEdition := 3
-
-	// SPConfig expect
-	spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
-		AddRow("allow polybase export", 0, 1, 0, 0).
-		AddRow("allow updates", 0, 1, 0, 0)
-	mock.ExpectQuery(spConfigQuery).WillReturnRows(spConfigRows)
-
-	// sys.configurations expect
-	mock.ExpectQuery(sysConfigQuery).WillReturnError(errors.New("error"))
-
-	PopulateInventory(e, conn, engineEdition)
-
-	// expected inventory.Items map to be set
-	expected := map[string]inventory.Item{
-		"allow polybase export/run_value": {"value": 0},
-		"allow updates/run_value":         {"value": 0},
-	}
-
-	// reflect.DeepEqual did not work on comparing Items maps so did a manual comparison
-	equal := true
-	for k, expectedV := range expected {
-		v, ok := e.Inventory.Item(k)
-		if !ok {
-			equal = false
-			break
-		}
-
-		if !reflect.DeepEqual(expectedV, v) {
-			equal = false
-			break
-		}
-	}
-
-	if !equal {
-		t.Errorf("Expected %+v got %+v", expected, e.Inventory.Items())
+		runTestPopulateInventory(t, tt)
 	}
 }

--- a/src/testdata/azureSQLDatabaseMetricsWithoutMemoryMetrics.json.golden
+++ b/src/testdata/azureSQLDatabaseMetricsWithoutMemoryMetrics.json.golden
@@ -30,18 +30,13 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 0,
                     "displayName": "db-1",
                     "entityName": "ms-database:db-1",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 0,
                     "log.transactionGrowth": 0,
-                    "memoryUtilization": 31.18,
-                    "memoryTotal": 2097152,
-                    "memoryAvailable": 1443260.0063999998, 
                     "pageFileTotal": 0,
                     "pageFileAvailable": 0,
                     "reportingEndpoint": "testhost"
@@ -67,18 +62,13 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 1,
                     "displayName": "db-2",
                     "entityName": "ms-database:db-2",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
-                    "memoryUtilization": 31.18,
-                    "memoryTotal": 2097152,
-                    "memoryAvailable": 1443260.0063999998,
                     "pageFileTotal": 1,
                     "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"

--- a/src/testdata/databasePartialMemoryMetrics.json.golden
+++ b/src/testdata/databasePartialMemoryMetrics.json.golden
@@ -30,18 +30,14 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 0,
                     "displayName": "db-1",
                     "entityName": "ms-database:db-1",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 0,
                     "log.transactionGrowth": 0,
                     "memoryUtilization": 31.18,
-                    "memoryTotal": 2097152,
-                    "memoryAvailable": 1443260.0063999998, 
                     "pageFileTotal": 0,
                     "pageFileAvailable": 0,
                     "reportingEndpoint": "testhost"
@@ -67,18 +63,14 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 1,
                     "displayName": "db-2",
                     "entityName": "ms-database:db-2",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
                     "memoryUtilization": 31.18,
-                    "memoryTotal": 2097152,
-                    "memoryAvailable": 1443260.0063999998,
                     "pageFileTotal": 1,
                     "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"

--- a/src/testdata/partialAzureSQLDatabaseMetrics.json.golden
+++ b/src/testdata/partialAzureSQLDatabaseMetrics.json.golden
@@ -63,8 +63,12 @@
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
+                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
+                    "memoryUtilization": 31.18,
+                    "memoryTotal": 2097152,
+                    "memoryAvailable": 1443260.0063999998,
                     "pageFileTotal": 1,
                     "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"


### PR DESCRIPTION
### Description

- Add new queries to populate `memoryUtilization`, `memoryTotal`, `memoryAvailable`, `maxDiskSizeInBytes` for azure sql database.
- Add logic to execute queries and populate the above mentioned metrics per database when instrumenting an azure sql database i.e the metrics should come under MssqlDatabaseSample
- Added unit tests for the same.

Docs update - https://github.com/newrelic/docs-website/pull/20674

<details><summary> Testing Details: </summary>
<p>

```shell
root@sairaj-mssql-test-2:/home/sairaj/nri-mssql/bin# ./nri-mssql -username="newrelic"  -password="***" -port=1433 -hostname="test.database.windows.net" -enable_buffer_metrics=true -enable_database_reserve_metrics=true -enable_disk_metrics_in_bytes -verbose=true
09:29:30.001434 [DEBUG] store file (/tmp/nr-integrations/com.newrelic.mssql-620af03b7337b72def7d45b9e21132e3.json) is older than 6m0s, skipping loading from disk.
[DEBUG] Running query: select COALESCE( @@SERVERNAME, SERVERPROPERTY('ServerName'), SERVERPROPERTY('MachineName')) as instance_name
[DEBUG] Running query: SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition;
[DEBUG] Running query: SELECT name, value_in_use FROM sys.configurations
[DEBUG] Running query: select name, value from sys.configurations
[DEBUG] Running query: select name as db_name from sys.databases where name not in ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
[DEBUG] using database name : testdb as a query parameter in the connection url
[DEBUG] using database name : AdventureWorks as a query parameter in the connection url
[DEBUG] using database name : ohai-test-db-1 as a query parameter in the connection url
[DEBUG] Running query: 
                        SELECT 
                            sd.name AS db_name,
                            spc.cntr_value AS log_growth
                        FROM sys.dm_os_performance_counters spc
                        INNER JOIN sys.databases sd 
                            ON sd.physical_database_name = spc.instance_name
                        WHERE spc.counter_name = 'Log Growths'
                            AND spc.object_name LIKE '%:Databases%'
                            AND sd.database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                            DB_NAME() AS db_name,
                            SUM(io_stall) AS io_stalls
                        FROM sys.dm_io_virtual_file_stats(NULL, NULL)
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT DB_NAME() AS db_name, CAST(DATABASEPROPERTYEX(DB_NAME(), 'MaxSizeInBytes') AS BIGINT) AS total_disk_space;

[DEBUG] Running query: SELECT top 1 DB_NAME() AS db_name, avg_memory_usage_percent AS memory_utilization FROM sys.dm_db_resource_stats ORDER BY end_time DESC;
[DEBUG] Running query: SELECT DB_NAME() AS db_name, (process_memory_limit_mb * 1024 * 1024) AS total_physical_memory FROM sys.dm_os_job_object;
[DEBUG] Running query: 
                        SELECT 
                            DB_NAME() AS db_name, 
                            COUNT_BIG(*) * (8 * 1024) AS buffer_pool_size
                        FROM sys.dm_os_buffer_descriptors WITH (NOLOCK) 
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT 
                            sd.name AS db_name,
                            spc.cntr_value AS log_growth
                        FROM sys.dm_os_performance_counters spc
                        INNER JOIN sys.databases sd 
                            ON sd.physical_database_name = spc.instance_name
                        WHERE spc.counter_name = 'Log Growths'
                            AND spc.object_name LIKE '%:Databases%'
                            AND sd.database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                            DB_NAME() AS db_name,
                            SUM(io_stall) AS io_stalls
                        FROM sys.dm_io_virtual_file_stats(NULL, NULL)
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                                DB_NAME() AS db_name,
                                sum(a.total_pages) * 8.0 * 1024 AS reserved_space,
                                (sum(a.total_pages)*8.0 - sum(a.used_pages)*8.0) * 1024 AS reserved_space_not_used
                        FROM sys.partitions p with (nolock)
                        INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                        LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id

[DEBUG] Running query: 
                        SELECT DB_NAME() AS db_name, CAST(DATABASEPROPERTYEX(DB_NAME(), 'MaxSizeInBytes') AS BIGINT) AS total_disk_space;

[DEBUG] Running query: SELECT top 1 DB_NAME() AS db_name, avg_memory_usage_percent AS memory_utilization FROM sys.dm_db_resource_stats ORDER BY end_time DESC;
[DEBUG] Running query: 
                        SELECT 
                            sd.name AS db_name,
                            spc.cntr_value AS log_growth
                        FROM sys.dm_os_performance_counters spc
                        INNER JOIN sys.databases sd 
                            ON sd.physical_database_name = spc.instance_name
                        WHERE spc.counter_name = 'Log Growths'
                            AND spc.object_name LIKE '%:Databases%'
                            AND sd.database_id = DB_ID()

[DEBUG] Running query: SELECT DB_NAME() AS db_name, (process_memory_limit_mb * 1024 * 1024) AS total_physical_memory FROM sys.dm_os_job_object;
[DEBUG] Running query: 
                        SELECT 
                            DB_NAME() AS db_name, 
                            COUNT_BIG(*) * (8 * 1024) AS buffer_pool_size
                        FROM sys.dm_os_buffer_descriptors WITH (NOLOCK) 
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                            DB_NAME() AS db_name,
                            SUM(io_stall) AS io_stalls
                        FROM sys.dm_io_virtual_file_stats(NULL, NULL)
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT DB_NAME() AS db_name, CAST(DATABASEPROPERTYEX(DB_NAME(), 'MaxSizeInBytes') AS BIGINT) AS total_disk_space;

[DEBUG] Running query: SELECT top 1 DB_NAME() AS db_name, avg_memory_usage_percent AS memory_utilization FROM sys.dm_db_resource_stats ORDER BY end_time DESC;
[DEBUG] Running query: 
                        SELECT
                                DB_NAME() AS db_name,
                                sum(a.total_pages) * 8.0 * 1024 AS reserved_space,
                                (sum(a.total_pages)*8.0 - sum(a.used_pages)*8.0) * 1024 AS reserved_space_not_used
                        FROM sys.partitions p with (nolock)
                        INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                        LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id

[DEBUG] Running query: SELECT DB_NAME() AS db_name, (process_memory_limit_mb * 1024 * 1024) AS total_physical_memory FROM sys.dm_os_job_object;
[DEBUG] Running query: 
                        SELECT 
                            DB_NAME() AS db_name, 
                            COUNT_BIG(*) * (8 * 1024) AS buffer_pool_size
                        FROM sys.dm_os_buffer_descriptors WITH (NOLOCK) 
                        WHERE database_id = DB_ID()

[DEBUG] Running query: 
                        SELECT
                                DB_NAME() AS db_name,
                                sum(a.total_pages) * 8.0 * 1024 AS reserved_space,
                                (sum(a.total_pages)*8.0 - sum(a.used_pages)*8.0) * 1024 AS reserved_space_not_used
                        FROM sys.partitions p with (nolock)
                        INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
                        LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id

[DEBUG] Running query: SELECT
                t1.cntr_value AS sql_compilations,
                t2.cntr_value AS sql_recompilations,
                t3.cntr_value AS user_connections,
                t4.cntr_value AS lock_wait_time_ms,
                t5.cntr_value AS page_splits_sec,
                t6.cntr_value AS checkpoint_pages_sec,
                t7.cntr_value AS deadlocks_sec,
                t8.cntr_value AS user_errors,
                t9.cntr_value AS kill_connection_errors,
                t10.cntr_value AS batch_request_sec,
                (t11.cntr_value * 1000.0) AS page_life_expectancy_ms,
                t12.cntr_value AS transactions_sec,
                t13.cntr_value AS forced_parameterizations_sec
                FROM 
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'SQL Compilations/sec') t1,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'SQL Re-Compilations/sec') t2,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'User Connections') t3,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Lock Wait Time (ms)' AND instance_name = '_Total') t4,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Page Splits/sec') t5,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Checkpoint pages/sec') t6,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Number of Deadlocks/sec' AND instance_name = '_Total') t7,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE object_name LIKE '%SQL Errors%' AND instance_name = 'User Errors') t8,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE object_name LIKE '%SQL Errors%' AND instance_name LIKE 'Kill Connection Errors%') t9,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Batch Requests/sec') t10,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Page life expectancy' AND object_name LIKE '%Manager%') t11,
                (SELECT Sum(cntr_value) AS cntr_value FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Transactions/sec') t12,
                (SELECT * FROM sys.dm_os_performance_counters WITH (nolock) WHERE counter_name = 'Forced Parameterizations/sec') t13
[DEBUG] Running query: SELECT (a.cntr_value * 1.0 / b.cntr_value) * 100.0 AS buffer_pool_hit_percent
                FROM sys.dm_os_performance_counters 
                a JOIN (SELECT cntr_value, OBJECT_NAME FROM sys.dm_os_performance_counters WHERE counter_name = 'Buffer cache hit ratio base') 
                b ON  a.OBJECT_NAME = b.OBJECT_NAME 
                WHERE a.counter_name = 'Buffer cache hit ratio'
[DEBUG] Running query: SELECT
                Sum(wait_time_ms) AS wait_time
                FROM sys.dm_os_wait_stats
                WHERE [wait_type] NOT IN (
                N'CLR_SEMAPHORE',    N'LAZYWRITER_SLEEP',
                N'RESOURCE_QUEUE',   N'SQLTRACE_BUFFER_FLUSH',
                N'SLEEP_TASK',       N'SLEEP_SYSTEMTASK',
                N'WAITFOR',          N'HADR_FILESTREAM_IOMGR_IOCOMPLETION',
                N'CHECKPOINT_QUEUE', N'REQUEST_FOR_DEADLOCK_SEARCH',
                N'XE_TIMER_EVENT',   N'XE_DISPATCHER_JOIN',
                N'LOGMGR_QUEUE',     N'FT_IFTS_SCHEDULER_IDLE_WAIT',
                N'BROKER_TASK_STOP', N'CLR_MANUAL_EVENT',
                N'CLR_AUTO_EVENT',   N'DISPATCHER_QUEUE_SEMAPHORE',
                N'TRACEWRITE',       N'XE_DISPATCHER_WAIT',
                N'BROKER_TO_FLUSH',  N'BROKER_EVENTHANDLER',
                N'FT_IFTSHC_MUTEX',  N'SQLTRACE_INCREMENTAL_FLUSH_SLEEP',
                N'DIRTY_PAGE_POLL',  N'SP_SERVER_DIAGNOSTICS_SLEEP')
[DEBUG] Running query: SELECT
                Max(CASE WHEN sessions.status = 'preconnect' THEN counts ELSE 0 END) AS preconnect,
                Max(CASE WHEN sessions.status = 'background' THEN counts ELSE 0 END) AS background,
                Max(CASE WHEN sessions.status = 'dormant' THEN counts ELSE 0 END) AS dormant,
                Max(CASE WHEN sessions.status = 'runnable' THEN counts ELSE 0 END) AS runnable,
                Max(CASE WHEN sessions.status = 'suspended' THEN counts ELSE 0 END) AS suspended,
                Max(CASE WHEN sessions.status = 'running' THEN counts ELSE 0 END) AS running,
                Max(CASE WHEN sessions.status = 'blocked' THEN counts ELSE 0 END) AS blocked,
                Max(CASE WHEN sessions.status = 'sleeping' THEN counts ELSE 0 END) AS sleeping
                FROM (SELECT status, Count(*) counts FROM (
                        SELECT CASE WHEN req.status IS NOT NULL THEN
                                CASE WHEN req.blocking_session_id <> 0 THEN 'blocked' ELSE req.status END
                          ELSE sess.status END status, req.blocking_session_id
                        FROM sys.dm_exec_sessions sess
                        LEFT JOIN sys.dm_exec_requests req
                        ON sess.session_id = req.session_id
                        WHERE sess.session_id > 50 ) statuses
                  GROUP BY status) sessions
[DEBUG] Running query: SELECT Sum(runnable_tasks_count) AS runnable_tasks_count
                FROM sys.dm_os_schedulers
                WHERE   scheduler_id < 255 AND [status] = 'VISIBLE ONLINE'
[DEBUG] Running query: SELECT Count(dbid) AS instance_active_connections FROM sys.sysprocesses WITH (nolock) WHERE dbid > 0
[DEBUG] Skipping query 'SELECT
                Max(sys_mem.total_physical_memory_kb * 1024.0) AS total_physical_memory,
                Max(sys_mem.available_physical_memory_kb * 1024.0) AS available_physical_memory,
                (Max(proc_mem.physical_memory_in_use_kb) / (Max(sys_mem.total_physical_memory_kb) * 1.0)) * 100 AS memory_utilization
                FROM sys.dm_os_process_memory proc_mem,
                  sys.dm_os_sys_memory sys_mem,
                  sys.dm_os_performance_counters perf_count WHERE object_name = 'SQLServer:Memory Manager'' for unsupported engine edition 5
[DEBUG] Running query:  SELECT
      Count_big(*) * (8*1024) AS instance_buffer_pool_size
      FROM sys.dm_os_buffer_descriptors WITH (nolock)
      WHERE database_id <> 32767 -- ResourceDB 
[DEBUG] Skipping query 'SELECT Sum(total_bytes) AS total_disk_space FROM (
                        SELECT DISTINCT
                        dovs.volume_mount_point,
                        dovs.available_bytes available_bytes,
                        dovs.total_bytes total_bytes
                        FROM sys.master_files mf WITH (nolock)
                        CROSS apply sys.Dm_os_volume_stats(mf.database_id, mf.file_id) dovs
                        ) drives' for unsupported engine edition 5
[DEBUG] Running query: SELECT wait_type, wait_time_ms AS wait_time, waiting_tasks_count
FROM sys.dm_os_wait_stats wait_stats
WHERE wait_time_ms != 0
output.json was printed here.
root@sairaj-mssql-test-2:/home/sairaj/nri-mssql/bin# 
``` 

</p>
</details> 

[output.json](https://github.com/user-attachments/files/20752775/output.json)
