### PR TITLE
feat: Add regular monitoring support for azure sql database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### enhancement
+- Add support for monitoring Azure SQL Database
+
 ## v2.18.2 - 2025-06-03
 
 ### ⛓️ Dependencies

--- a/spec.csv
+++ b/spec.csv
@@ -13,9 +13,10 @@ MS SQL,stats.userErrorsPerSecond,Rate,true,Number of user errors per second sinc
 MS SQL,stats.killConnectionErrorsPerSecond,Rate,true,Number of kill connection errors per second since last restart
 MS SQL,log.transactionGrowth,Gauge,true,Total number of times the transaction log for the database has been expanded last restart
 MS SQL,iO.stallInMiliseconds,Gauge,true,Wait time of stall since last restart in Miliseconds
-MS SQL,memoryUtilization,Gauge,true,Percentage of Memory Utilization
-MS SQL,memoryTotal,Gauge,true,Total Physical memory in Bytes
-MS SQL,memoryAvailable,Gauge,true,Available physical memory in Bytes
+MS SQL,maxDiskSizeInBytes,Gauge,true,Maximum database size in bytes. Applies to: Azure SQL Database.
+MS SQL,memoryUtilization,Gauge,true,Percentage of Memory Utilization. Note: This metric is populated per database in case of Azure SQL Database.
+MS SQL,memoryTotal,Gauge,true,Total Physical memory in Bytes. Note: This metric is populated per database in case of Azure SQL Database.
+MS SQL,memoryAvailable,Gauge,true,Available physical memory in Bytes. Note: This metric is populated per database in case of Azure SQL Database.
 MS SQL,pageFileTotal,Gauge,true,Total Page File in Bytes
 MS SQL,pageFileAvailable,Gauge,true,Availbe page file in Bytes
 MS SQL,system.bufferPoolHit,Gauge,true,The percentage of buffer pools hits on the instance

--- a/spec.csv
+++ b/spec.csv
@@ -14,9 +14,9 @@ MS SQL,stats.killConnectionErrorsPerSecond,Rate,true,Number of kill connection e
 MS SQL,log.transactionGrowth,Gauge,true,Total number of times the transaction log for the database has been expanded last restart
 MS SQL,iO.stallInMiliseconds,Gauge,true,Wait time of stall since last restart in Miliseconds
 MS SQL,maxDiskSizeInBytes,Gauge,true,Maximum database size in bytes. Applies to: Azure SQL Database.
-MS SQL,memoryUtilization,Gauge,true,Percentage of Memory Utilization. Note: This metric is populated per database in case of Azure SQL Database.
-MS SQL,memoryTotal,Gauge,true,Total Physical memory in Bytes. Note: This metric is populated per database in case of Azure SQL Database.
-MS SQL,memoryAvailable,Gauge,true,Available physical memory in Bytes. Note: This metric is populated per database in case of Azure SQL Database.
+MS SQL,memoryUtilization,Gauge,true,Percentage of Memory Utilization. Note: This metric is populated per database while monitoring Azure SQL Database.
+MS SQL,memoryTotal,Gauge,true,Total Physical memory in Bytes. Note: This metric is populated per database while monitoring Azure SQL Database.
+MS SQL,memoryAvailable,Gauge,true,Available physical memory in Bytes. Note: This metric is populated per database while monitoring Azure SQL Database.
 MS SQL,pageFileTotal,Gauge,true,Total Page File in Bytes
 MS SQL,pageFileAvailable,Gauge,true,Availbe page file in Bytes
 MS SQL,system.bufferPoolHit,Gauge,true,The percentage of buffer pools hits on the instance

--- a/src/common/query_skip.go
+++ b/src/common/query_skip.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"strings"
+
+	"github.com/newrelic/nri-mssql/src/database"
+)
+
+var UnsupportedQueryPatterns = map[int][]string{
+	database.AzureSQLDatabaseEngineEditionNumber: { // Azure SQL Database EngineEdition
+		"sys.dm_os_process_memory",
+		"sys.master_files",
+		"exec sp_configure",
+		"sys.dm_os_sys_memory",
+		"sys.dm_os_volume_stats",
+	},
+}
+
+func ShouldSkipQueryForEngineEdition(engineEdition int, query string) bool {
+	for _, pattern := range UnsupportedQueryPatterns[engineEdition] {
+		if strings.Contains(strings.ToLower(query), strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/common/query_skip.go
+++ b/src/common/query_skip.go
@@ -16,7 +16,7 @@ var UnsupportedQueryPatterns = map[int][]string{
 	},
 }
 
-func ShouldSkipQueryForEngineEdition(engineEdition int, query string) bool {
+func SkipQueryForEngineEdition(engineEdition int, query string) bool {
 	for _, pattern := range UnsupportedQueryPatterns[engineEdition] {
 		if strings.Contains(strings.ToLower(query), strings.ToLower(pattern)) {
 			return true

--- a/src/connection/sql_connection.go
+++ b/src/connection/sql_connection.go
@@ -21,7 +21,21 @@ type SQLConnection struct {
 
 // NewConnection creates a new SQLConnection from args
 func NewConnection(args *args.ArgumentList) (*SQLConnection, error) {
-	db, err := sqlx.Connect("mssql", CreateConnectionURL(args))
+	db, err := sqlx.Connect("mssql", CreateConnectionURL(args, ""))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLConnection{
+		Connection: db,
+		Host:       args.Hostname,
+	}, nil
+}
+
+// package-level variable to hold the original function which is needed to mock this NewDatabaseConnection for unit testing.
+var CreateDatabaseConnection = NewDatabaseConnection
+
+func NewDatabaseConnection(args *args.ArgumentList, dbName string) (*SQLConnection, error) {
+	db, err := sqlx.Connect("mssql", CreateConnectionURL(args, dbName))
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +66,7 @@ func (sc SQLConnection) Queryx(query string) (*sqlx.Rows, error) {
 
 // CreateConnectionURL tags in args and creates the connection string.
 // All args should be validated before calling this.
-func CreateConnectionURL(args *args.ArgumentList) string {
-
+func CreateConnectionURL(args *args.ArgumentList, dbName string) string {
 	connectionString := ""
 
 	connectionURL := &url.URL{
@@ -73,6 +86,10 @@ func CreateConnectionURL(args *args.ArgumentList) string {
 	query := url.Values{}
 	query.Add("dial timeout", args.Timeout)
 	query.Add("connection timeout", args.Timeout)
+	if dbName != "" {
+		query.Add("database", dbName)
+		log.Debug("using database name : %s as a query parameter in the connection url", dbName)
+	}
 
 	if args.ExtraConnectionURLArgs != "" {
 		extraArgsMap, err := url.ParseQuery(args.ExtraConnectionURLArgs)

--- a/src/connection/sql_connection_test.go
+++ b/src/connection/sql_connection_test.go
@@ -54,9 +54,10 @@ func Test_SQLConnection_Query(t *testing.T) {
 
 func Test_createConnectionURL(t *testing.T) {
 	testCases := []struct {
-		name string
-		arg  *args.ArgumentList
-		want string
+		name   string
+		arg    *args.ArgumentList
+		dbName string
+		want   string
 	}{
 		{
 			"Port No SSL",
@@ -68,6 +69,7 @@ func Test_createConnectionURL(t *testing.T) {
 				Port:      "1443",
 				Timeout:   "30",
 			},
+			"",
 			"sqlserver://user:pass@localhost:1443?connection+timeout=30&dial+timeout=30",
 		},
 		{
@@ -80,6 +82,7 @@ func Test_createConnectionURL(t *testing.T) {
 				Instance:  "SQLExpress",
 				Timeout:   "30",
 			},
+			"",
 			"sqlserver://user:pass@localhost/SQLExpress?connection+timeout=30&dial+timeout=30",
 		},
 		{
@@ -93,6 +96,7 @@ func Test_createConnectionURL(t *testing.T) {
 				Instance:               "SQLExpress",
 				Timeout:                "30",
 			},
+			"",
 			"sqlserver://user:pass@localhost/SQLExpress?TrustServerCertificate=true&connection+timeout=30&dial+timeout=30&encrypt=true",
 		},
 		{
@@ -107,6 +111,7 @@ func Test_createConnectionURL(t *testing.T) {
 				Instance:               "SQLExpress",
 				Timeout:                "30",
 			},
+			"",
 			"sqlserver://user:pass@localhost/SQLExpress?TrustServerCertificate=false&certificate=file.ca&connection+timeout=30&dial+timeout=30&encrypt=true",
 		},
 		{
@@ -120,12 +125,26 @@ func Test_createConnectionURL(t *testing.T) {
 				Timeout:                "30",
 				ExtraConnectionURLArgs: "applicationIntent=true",
 			},
+			"",
 			"sqlserver://user:pass@localhost:1443?applicationIntent=true&connection+timeout=30&dial+timeout=30",
+		},
+		{
+			"Database Name",
+			&args.ArgumentList{
+				Username:  "user",
+				Password:  "pass",
+				Hostname:  "localhost",
+				EnableSSL: false,
+				Port:      "1443",
+				Timeout:   "30",
+			},
+			"test-db",
+			"sqlserver://user:pass@localhost:1443?connection+timeout=30&database=test-db&dial+timeout=30",
 		},
 	}
 
 	for _, tc := range testCases {
-		if out := CreateConnectionURL(tc.arg); out != tc.want {
+		if out := CreateConnectionURL(tc.arg, tc.dbName); out != tc.want {
 			t.Errorf("Test Case %s Failed: Expected '%s' got '%s'", tc.name, tc.want, out)
 		}
 	}

--- a/src/database/sql_database.go
+++ b/src/database/sql_database.go
@@ -15,7 +15,7 @@ import (
 // databaseNameQuery gets all database names
 const databaseNameQuery = "select name as db_name from sys.databases where name not in ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')"
 const engineEditionQuery = "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition;"
-const azureSQLDatabaseEngineEditionNumber = 5
+const AzureSQLDatabaseEngineEditionNumber = 5
 
 // NameRow is a row result in the databaseNameQuery
 type NameRow struct {
@@ -133,5 +133,5 @@ func GetEngineEdition(connection *connection.SQLConnection) (int, error) {
 
 // IsAzureSQLDatabase checks if the given engine edition corresponds to Azure SQL Database with EngineEdition value of 5
 func IsAzureSQLDatabase(engineEdition int) bool {
-	return engineEdition == azureSQLDatabaseEngineEditionNumber
+	return engineEdition == AzureSQLDatabaseEngineEditionNumber
 }

--- a/src/database/sql_database.go
+++ b/src/database/sql_database.go
@@ -2,16 +2,20 @@
 package database
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/newrelic/infra-integrations-sdk/v3/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
+	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"github.com/newrelic/nri-mssql/src/connection"
 )
 
 // databaseNameQuery gets all database names
 const databaseNameQuery = "select name as db_name from sys.databases where name not in ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')"
+const engineEditionQuery = "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition;"
+const azureSQLDatabaseEngineEditionNumber = 5
 
 // NameRow is a row result in the databaseNameQuery
 type NameRow struct {
@@ -111,4 +115,23 @@ func CreateDBEntitySetLookup(dbEntities []*integration.Entity, instanceName, hos
 	}
 
 	return entitySetLookup
+}
+
+// GetEngineEdition retrieves the engine edition from the database.
+func GetEngineEdition(connection *connection.SQLConnection) (int, error) {
+	var engineEdition []int
+	if err := connection.Query(&engineEdition, engineEditionQuery); err != nil {
+		return 0, fmt.Errorf("error querying EngineEdition: %w", err)
+	}
+	if len(engineEdition) == 0 {
+		log.Debug("EngineEdition query returned empty output.")
+		return 0, nil
+	} else {
+		return engineEdition[0], nil
+	}
+}
+
+// IsAzureSQLDatabase checks if the given engine edition corresponds to Azure SQL Database with EngineEdition value of 5
+func IsAzureSQLDatabase(engineEdition int) bool {
+	return engineEdition == azureSQLDatabaseEngineEditionNumber
 }

--- a/src/database/sql_database_test.go
+++ b/src/database/sql_database_test.go
@@ -196,10 +196,10 @@ func TestGetEngineEdition(t *testing.T) {
 			name: "Successful query - Azure SQL DB",
 			setupMock: func(mock sqlmock.Sqlmock) {
 				expectedRows := sqlmock.NewRows([]string{"EngineEdition"}).
-					AddRow(azureSQLDatabaseEngineEditionNumber)
+					AddRow(AzureSQLDatabaseEngineEditionNumber)
 				mock.ExpectQuery("SELECT (.+)").WillReturnRows(expectedRows)
 			},
-			expectedEdition: azureSQLDatabaseEngineEditionNumber,
+			expectedEdition: AzureSQLDatabaseEngineEditionNumber,
 			expectError:     false,
 		},
 		{
@@ -255,7 +255,7 @@ func TestIsAzureSQLDatabase(t *testing.T) {
 	}{
 		{
 			name:          "Azure SQL Database",
-			engineEdition: azureSQLDatabaseEngineEditionNumber,
+			engineEdition: AzureSQLDatabaseEngineEditionNumber,
 			expected:      true,
 		},
 		{

--- a/src/database/sql_database_test.go
+++ b/src/database/sql_database_test.go
@@ -9,8 +9,11 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/v3/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/nri-mssql/src/connection"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
+
+const azureSQLManagedInstanceEngineEditionNumber = 8
 
 func Test_createDatabaseEntities_QueryError(t *testing.T) {
 	i, err := integration.New("test", "1.0.0")
@@ -179,5 +182,93 @@ func Test_createDBEntitySetLookUp(t *testing.T) {
 	out := CreateDBEntitySetLookup(entities, "MSSQL", "myHost")
 	if !reflect.DeepEqual(out, expected) {
 		t.Errorf("Expected %+v got %+v", expected, out)
+	}
+}
+
+func TestGetEngineEdition(t *testing.T) {
+	testCases := []struct {
+		name            string
+		setupMock       func(sqlmock.Sqlmock)
+		expectedEdition int
+		expectError     bool
+	}{
+		{
+			name: "Successful query - Azure SQL DB",
+			setupMock: func(mock sqlmock.Sqlmock) {
+				expectedRows := sqlmock.NewRows([]string{"EngineEdition"}).
+					AddRow(azureSQLDatabaseEngineEditionNumber)
+				mock.ExpectQuery("SELECT (.+)").WillReturnRows(expectedRows)
+			},
+			expectedEdition: azureSQLDatabaseEngineEditionNumber,
+			expectError:     false,
+		},
+		{
+			name: "Successful query - Other SQL Server",
+			setupMock: func(mock sqlmock.Sqlmock) {
+				expectedRows := sqlmock.NewRows([]string{"EngineEdition"}).
+					AddRow(azureSQLManagedInstanceEngineEditionNumber)
+				mock.ExpectQuery("SELECT (.+)").WillReturnRows(expectedRows)
+			},
+			expectedEdition: azureSQLManagedInstanceEngineEditionNumber,
+			expectError:     false,
+		},
+		{
+			name: "Query error",
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT (.+)").WillReturnError(assert.AnError)
+			},
+			expectedEdition: 0,
+			expectError:     true,
+		},
+		{
+			name: "Empty output from engine edition query",
+			setupMock: func(mock sqlmock.Sqlmock) {
+				expectedRows := sqlmock.NewRows([]string{"EngineEdition"})
+				mock.ExpectQuery("SELECT (.+)").WillReturnRows(expectedRows)
+			},
+			expectedEdition: 0,
+			expectError:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, mock := connection.CreateMockSQL(t)
+			tc.setupMock(mock)
+			actualEdition, err := GetEngineEdition(conn)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tc.expectedEdition, actualEdition)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsAzureSQLDatabase(t *testing.T) {
+	testCases := []struct {
+		name          string
+		engineEdition int
+		expected      bool
+	}{
+		{
+			name:          "Azure SQL Database",
+			engineEdition: azureSQLDatabaseEngineEditionNumber,
+			expected:      true,
+		},
+		{
+			name:          "Azure SQL Managed Instance",
+			engineEdition: azureSQLManagedInstanceEngineEditionNumber,
+			expected:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := IsAzureSQLDatabase(tc.engineEdition)
+			assert.Equal(t, tc.expected, actual)
+		})
 	}
 }

--- a/src/inventory/inventory.go
+++ b/src/inventory/inventory.go
@@ -4,13 +4,14 @@ package inventory
 import (
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
-	"github.com/newrelic/nri-mssql/src/common"
 	"github.com/newrelic/nri-mssql/src/connection"
+	"github.com/newrelic/nri-mssql/src/metrics"
 )
 
 const (
-	spConfigQuery  = "EXEC sp_configure"
-	sysConfigQuery = "select name, value from sys.configurations"
+	spConfigQuery                    = "EXEC sp_configure"
+	sysConfigQuery                   = "select name, value from sys.configurations"
+	spConfigQueryForAzureSQLDatabase = "SELECT name, value_in_use FROM sys.configurations"
 )
 
 // SPConfigRow represents a row in the table returned by spConfigQuery
@@ -22,11 +23,18 @@ type SPConfigRow struct {
 	RunValue    int    `db:"run_value"`
 }
 
+type SPConfigRowForAzureSQLDatabase struct {
+	Name     string `db:"name"`
+	RunValue int    `db:"value_in_use"`
+}
+
 // ConfigQueryRow represents a row in the table returned by sysConfigQuery
 type ConfigQueryRow struct {
 	Name  string `db:"name"`
 	Value int    `db:"value"`
 }
+
+type spConfigItemsProcessor func(instanceEntity *integration.Entity, connection *connection.SQLConnection) error
 
 // PopulateInventory gathers inventory data for the SQL Server instance and populates it into entity
 func PopulateInventory(instanceEntity *integration.Entity, connection *connection.SQLConnection, engineEdition int) {
@@ -41,21 +49,10 @@ func PopulateInventory(instanceEntity *integration.Entity, connection *connectio
 
 // populateSPConfigItems collects inventory items for sp_configure procedure
 func populateSPConfigItems(instanceEntity *integration.Entity, connection *connection.SQLConnection, engineEdition int) error {
-	if common.ShouldSkipQueryForEngineEdition(engineEdition, spConfigQuery) {
-		log.Debug("Skipping query '%s' for unsupported engine edition %d", spConfigQuery, engineEdition)
-
-		return nil
-	}
-	configRows := make([]*SPConfigRow, 0)
-	if err := connection.Query(&configRows, spConfigQuery); err != nil {
+	processor := spConfigProcessorFunctionSet.Select(engineEdition)
+	if err := processor(instanceEntity, connection); err != nil {
 		return err
 	}
-
-	for _, row := range configRows {
-		itemName := row.Name + "/run_value"
-		setItemOrLog(instanceEntity, itemName, row.RunValue)
-	}
-
 	return nil
 }
 
@@ -80,4 +77,36 @@ func setItemOrLog(instanceEntity *integration.Entity, key string, value interfac
 	if err := instanceEntity.SetInventoryItem(key, "value", value); err != nil {
 		log.Error("Error setting inventory item '%s': %s", key, err.Error())
 	}
+}
+
+// Bucket for processor functions
+var spConfigProcessorFunctionSet = metrics.EngineSet[spConfigItemsProcessor]{
+	Default:          processSPConfigItems,
+	AzureSQLDatabase: processAzureSQLDatabaseSPConfigItems,
+}
+
+func processSPConfigItems(instanceEntity *integration.Entity, connection *connection.SQLConnection) error {
+	configRows := make([]*SPConfigRow, 0)
+	if err := connection.Query(&configRows, spConfigQuery); err != nil {
+		return err
+	}
+
+	for _, row := range configRows {
+		itemName := row.Name + "/run_value"
+		setItemOrLog(instanceEntity, itemName, row.RunValue)
+	}
+	return nil
+}
+
+func processAzureSQLDatabaseSPConfigItems(instanceEntity *integration.Entity, connection *connection.SQLConnection) error {
+	configRows := make([]*SPConfigRowForAzureSQLDatabase, 0)
+	if err := connection.Query(&configRows, spConfigQueryForAzureSQLDatabase); err != nil {
+		return err
+	}
+
+	for _, row := range configRows {
+		itemName := row.Name + "/run_value"
+		setItemOrLog(instanceEntity, itemName, row.RunValue)
+	}
+	return nil
 }

--- a/src/inventory/inventory_test.go
+++ b/src/inventory/inventory_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/v3/data/inventory"
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/nri-mssql/src/connection"
+	"github.com/newrelic/nri-mssql/src/database"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
@@ -28,59 +29,96 @@ func CreateMockSQL(t *testing.T) (con *connection.SQLConnection, mock sqlmock.Sq
 }
 
 func Test_populateInventory(t *testing.T) {
-	i, err := integration.New("test", "1.0.0")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
+	// Uncomment the following line to enable logging during tests
+	// log.SetupLogging(true)
+	// defer log.SetupLogging(false)
+	tests := []struct {
+		name               string
+		spConfigSetup      func(mock sqlmock.Sqlmock) // Function to mock sp_configure query
+		sysConfigSetup     func(mock sqlmock.Sqlmock) // Function to mock sys.configurations query
+		expectedInventory  map[string]inventory.Item  // Expected inventory items
+		engineEditionValue int                        // Engine edition value
+	}{
+		{
+			name: "Successful inventory population",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
+					AddRow("allow polybase export", 0, 1, 0, 0).
+					AddRow("allow updates", 0, 1, 0, 0)
+				mock.ExpectQuery(spConfigQuery).WillReturnRows(spConfigRows)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
+					AddRow("allow polybase export", 1).
+					AddRow("allow updates", 1)
+				mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/run_value":    {"value": 0},
+				"allow updates/run_value":            {"value": 0},
+				"allow polybase export/config_value": {"value": 1},
+				"allow updates/config_value":         {"value": 1},
+			},
+			engineEditionValue: 3,
+		},
+		{
+			name: "Engine edition 5: Only sys.configurations items collected",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				// No rows/queries expected for sp_configure since it should be skipped
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
+					AddRow("allow polybase export", 1).
+					AddRow("allow updates", 1)
+				mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/config_value": {"value": 1},
+				"allow updates/config_value":         {"value": 1},
+			},
+			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber, // Azure SQL Database
+		},
 	}
 
-	e, err := i.Entity("test", "instance")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i, err := integration.New("test", "1.0.0")
+			if err != nil {
+				t.Fatalf("Unexpected error %s", err.Error())
+			}
 
-	conn, mock := CreateMockSQL(t)
+			e, err := i.Entity("test", "instance")
+			if err != nil {
+				t.Fatalf("Unexpected error %s", err.Error())
+			}
 
-	// SPConfig expect
-	spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
-		AddRow("allow polybase export", 0, 1, 0, 0).
-		AddRow("allow updates", 0, 1, 0, 0)
-	mock.ExpectQuery(spConfigQuery).WillReturnRows(spConfigRows)
+			conn, mock := CreateMockSQL(t)
 
-	// sys.configurations expect
-	sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
-		AddRow("allow polybase export", 1).
-		AddRow("allow updates", 1)
-	mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			// Setup mocks
+			tt.spConfigSetup(mock)
+			tt.sysConfigSetup(mock)
 
-	PopulateInventory(e, conn)
+			PopulateInventory(e, conn, tt.engineEditionValue)
 
-	// expected inventory.Items map to be set
-	expected := map[string]inventory.Item{
-		"allow polybase export/run_value":    {"value": 0},
-		"allow updates/run_value":            {"value": 0},
-		"allow polybase export/config_value": {"value": 1},
-		"allow updates/config_value":         {"value": 1},
-	}
+			// Validate inventory
+			equal := true
+			for k, expectedV := range tt.expectedInventory {
+				v, ok := e.Inventory.Item(k)
+				if !ok {
+					equal = false
+					break
+				}
 
-	// reflect.DeepEqual did not work on comparing Items maps so did a manual comparison
-	equal := true
-	for k, expectedV := range expected {
-		v, ok := e.Inventory.Item(k)
-		if !ok {
-			equal = false
-			break
-		}
+				if !reflect.DeepEqual(expectedV, v) {
+					equal = false
+					break
+				}
+			}
 
-		if !reflect.DeepEqual(expectedV, v) {
-			equal = false
-			break
-		}
-	}
-
-	if !equal {
-		t.Errorf("Expected %+v got %+v", expected, e.Inventory.Items())
+			if !equal {
+				t.Errorf("Expected %+v got %+v", tt.expectedInventory, e.Inventory.Items())
+			}
+		})
 	}
 }
 
@@ -99,6 +137,8 @@ func Test_populateInventory_SPConfigError(t *testing.T) {
 
 	conn, mock := CreateMockSQL(t)
 
+	engineEdition := 3
+
 	// SPConfig expect
 	mock.ExpectQuery(spConfigQuery).WillReturnError(errors.New("error"))
 
@@ -108,7 +148,7 @@ func Test_populateInventory_SPConfigError(t *testing.T) {
 		AddRow("allow updates", 1)
 	mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
 
-	PopulateInventory(e, conn)
+	PopulateInventory(e, conn, engineEdition)
 
 	// expected inventory.Items map to be set
 	expected := map[string]inventory.Item{
@@ -151,6 +191,8 @@ func Test_populateInventory_SysConfigError(t *testing.T) {
 
 	conn, mock := CreateMockSQL(t)
 
+	engineEdition := 3
+
 	// SPConfig expect
 	spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
 		AddRow("allow polybase export", 0, 1, 0, 0).
@@ -160,7 +202,7 @@ func Test_populateInventory_SysConfigError(t *testing.T) {
 	// sys.configurations expect
 	mock.ExpectQuery(sysConfigQuery).WillReturnError(errors.New("error"))
 
-	PopulateInventory(e, conn)
+	PopulateInventory(e, conn, engineEdition)
 
 	// expected inventory.Items map to be set
 	expected := map[string]inventory.Item{

--- a/src/inventory/inventory_test.go
+++ b/src/inventory/inventory_test.go
@@ -79,7 +79,7 @@ func runTestPopulateInventory(t *testing.T, tt InventoryTestCase) {
 	})
 }
 
-func Test_populateInventory(t *testing.T) {
+func Test_populateInventory_SuccessCases(t *testing.T) {
 	// Uncomment the following line to enable logging during tests
 	// log.SetupLogging(true)
 	// defer log.SetupLogging(false)
@@ -128,6 +128,17 @@ func Test_populateInventory(t *testing.T) {
 			},
 			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber, // Azure SQL Database
 		},
+	}
+	for _, tt := range tests {
+		runTestPopulateInventory(t, tt)
+	}
+}
+
+func Test_populateInventory_SPConfigErrorCases(t *testing.T) {
+	// Uncomment the following line to enable logging during tests
+	// log.SetupLogging(true)
+	// defer log.SetupLogging(false)
+	tests := []InventoryTestCase{
 		{
 			name: "Error spConfig and success sysConfig for regular sql server",
 			spConfigSetup: func(mock sqlmock.Sqlmock) {
@@ -162,6 +173,17 @@ func Test_populateInventory(t *testing.T) {
 			},
 			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber,
 		},
+	}
+	for _, tt := range tests {
+		runTestPopulateInventory(t, tt)
+	}
+}
+
+func Test_populateInventory_SysConfigErrorCases(t *testing.T) {
+	// Uncomment the following line to enable logging during tests
+	// log.SetupLogging(true)
+	// defer log.SetupLogging(false)
+	tests := []InventoryTestCase{
 		{
 			name: "Error sysConfig and success spConfig for regular sql server",
 			spConfigSetup: func(mock sqlmock.Sqlmock) {

--- a/src/inventory/inventory_test.go
+++ b/src/inventory/inventory_test.go
@@ -13,6 +13,8 @@ import (
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
+var errForTesting = errors.New("error")
+
 // CreateMockSQL creates a Test SQLConnection.
 func CreateMockSQL(t *testing.T) (con *connection.SQLConnection, mock sqlmock.Sqlmock) {
 	mockDB, mock, err := sqlmock.New()
@@ -28,19 +30,62 @@ func CreateMockSQL(t *testing.T) (con *connection.SQLConnection, mock sqlmock.Sq
 	return
 }
 
+type InventoryTestCase struct {
+	name               string
+	spConfigSetup      func(mock sqlmock.Sqlmock) // Function to mock sp_configure query
+	sysConfigSetup     func(mock sqlmock.Sqlmock) // Function to mock sys.configurations query
+	expectedInventory  map[string]inventory.Item  // Expected inventory items
+	engineEditionValue int                        // Engine edition value
+}
+
+func runTestPopulateInventory(t *testing.T, tt InventoryTestCase) {
+	t.Run(tt.name, func(t *testing.T) {
+		i, err := integration.New("test", "1.0.0")
+		if err != nil {
+			t.Fatalf("Unexpected error %s", err.Error())
+		}
+
+		e, err := i.Entity("test", "instance")
+		if err != nil {
+			t.Fatalf("Unexpected error %s", err.Error())
+		}
+
+		conn, mock := CreateMockSQL(t)
+
+		// Setup mocks
+		tt.spConfigSetup(mock)
+		tt.sysConfigSetup(mock)
+
+		PopulateInventory(e, conn, tt.engineEditionValue)
+
+		// Validate inventory
+		equal := true
+		for k, expectedV := range tt.expectedInventory {
+			v, ok := e.Inventory.Item(k)
+			if !ok {
+				equal = false
+				break
+			}
+
+			if !reflect.DeepEqual(expectedV, v) {
+				equal = false
+				break
+			}
+		}
+
+		if !equal {
+			t.Errorf("Expected %+v got %+v", tt.expectedInventory, e.Inventory.Items())
+		}
+	})
+}
+
 func Test_populateInventory(t *testing.T) {
 	// Uncomment the following line to enable logging during tests
 	// log.SetupLogging(true)
 	// defer log.SetupLogging(false)
-	tests := []struct {
-		name               string
-		spConfigSetup      func(mock sqlmock.Sqlmock) // Function to mock sp_configure query
-		sysConfigSetup     func(mock sqlmock.Sqlmock) // Function to mock sys.configurations query
-		expectedInventory  map[string]inventory.Item  // Expected inventory items
-		engineEditionValue int                        // Engine edition value
-	}{
+	tests := []InventoryTestCase{
 		{
-			name: "Successful inventory population",
+			name: "Successful inventory population for regular sql server",
 			spConfigSetup: func(mock sqlmock.Sqlmock) {
 				spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
 					AddRow("allow polybase export", 0, 1, 0, 0).
@@ -62,9 +107,31 @@ func Test_populateInventory(t *testing.T) {
 			engineEditionValue: 3,
 		},
 		{
-			name: "Engine edition 5: Only sys.configurations items collected",
+			name: "Successful inventory collection for azure sql database",
 			spConfigSetup: func(mock sqlmock.Sqlmock) {
-				// No rows/queries expected for sp_configure since it should be skipped
+				spConfigRows := sqlmock.NewRows([]string{"name", "value_in_use"}).
+					AddRow("allow polybase export", 2).
+					AddRow("allow updates", 2)
+				mock.ExpectQuery(spConfigQueryForAzureSQLDatabase).WillReturnRows(spConfigRows)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
+					AddRow("allow polybase export", 1).
+					AddRow("allow updates", 1)
+				mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/run_value":    {"value": 2},
+				"allow updates/run_value":            {"value": 2},
+				"allow polybase export/config_value": {"value": 1},
+				"allow updates/config_value":         {"value": 1},
+			},
+			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber, // Azure SQL Database
+		},
+		{
+			name: "Error spConfig and success sysConfig for regular sql server",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(spConfigQuery).WillReturnError(errForTesting)
 			},
 			sysConfigSetup: func(mock sqlmock.Sqlmock) {
 				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
@@ -76,156 +143,62 @@ func Test_populateInventory(t *testing.T) {
 				"allow polybase export/config_value": {"value": 1},
 				"allow updates/config_value":         {"value": 1},
 			},
+			engineEditionValue: 3,
+		},
+		{
+			name: "Error spConfig and success sysConfig for azure sql database",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(spConfigQueryForAzureSQLDatabase).WillReturnError(errForTesting)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
+					AddRow("allow polybase export", 1).
+					AddRow("allow updates", 1)
+				mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/config_value": {"value": 1},
+				"allow updates/config_value":         {"value": 1},
+			},
+			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber,
+		},
+		{
+			name: "Error sysConfig and success spConfig for regular sql server",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
+					AddRow("allow polybase export", 0, 1, 0, 0).
+					AddRow("allow updates", 0, 1, 0, 0)
+				mock.ExpectQuery(spConfigQuery).WillReturnRows(spConfigRows)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(sysConfigQuery).WillReturnError(errForTesting)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/run_value": {"value": 0},
+				"allow updates/run_value":         {"value": 0},
+			},
+			engineEditionValue: 3,
+		},
+		{
+			name: "Error sysConfig and success spConfig for azure sql database",
+			spConfigSetup: func(mock sqlmock.Sqlmock) {
+				spConfigRows := sqlmock.NewRows([]string{"name", "value_in_use"}).
+					AddRow("allow polybase export", 2).
+					AddRow("allow updates", 2)
+				mock.ExpectQuery(spConfigQueryForAzureSQLDatabase).WillReturnRows(spConfigRows)
+			},
+			sysConfigSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(sysConfigQuery).WillReturnError(errForTesting)
+			},
+			expectedInventory: map[string]inventory.Item{
+				"allow polybase export/run_value": {"value": 2},
+				"allow updates/run_value":         {"value": 2},
+			},
 			engineEditionValue: database.AzureSQLDatabaseEngineEditionNumber, // Azure SQL Database
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			i, err := integration.New("test", "1.0.0")
-			if err != nil {
-				t.Fatalf("Unexpected error %s", err.Error())
-			}
-
-			e, err := i.Entity("test", "instance")
-			if err != nil {
-				t.Fatalf("Unexpected error %s", err.Error())
-			}
-
-			conn, mock := CreateMockSQL(t)
-
-			// Setup mocks
-			tt.spConfigSetup(mock)
-			tt.sysConfigSetup(mock)
-
-			PopulateInventory(e, conn, tt.engineEditionValue)
-
-			// Validate inventory
-			equal := true
-			for k, expectedV := range tt.expectedInventory {
-				v, ok := e.Inventory.Item(k)
-				if !ok {
-					equal = false
-					break
-				}
-
-				if !reflect.DeepEqual(expectedV, v) {
-					equal = false
-					break
-				}
-			}
-
-			if !equal {
-				t.Errorf("Expected %+v got %+v", tt.expectedInventory, e.Inventory.Items())
-			}
-		})
-	}
-}
-
-func Test_populateInventory_SPConfigError(t *testing.T) {
-	i, err := integration.New("test", "1.0.0")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
-
-	e, err := i.Entity("test", "instance")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
-
-	conn, mock := CreateMockSQL(t)
-
-	engineEdition := 3
-
-	// SPConfig expect
-	mock.ExpectQuery(spConfigQuery).WillReturnError(errors.New("error"))
-
-	// sys.configurations expect
-	sysConfigRows := sqlmock.NewRows([]string{"name", "value"}).
-		AddRow("allow polybase export", 1).
-		AddRow("allow updates", 1)
-	mock.ExpectQuery(sysConfigQuery).WillReturnRows(sysConfigRows)
-
-	PopulateInventory(e, conn, engineEdition)
-
-	// expected inventory.Items map to be set
-	expected := map[string]inventory.Item{
-		"allow polybase export/config_value": {"value": 1},
-		"allow updates/config_value":         {"value": 1},
-	}
-
-	// reflect.DeepEqual did not work on comparing Items maps so did a manual comparison
-	equal := true
-	for k, expectedV := range expected {
-		v, ok := e.Inventory.Item(k)
-		if !ok {
-			equal = false
-			break
-		}
-
-		if !reflect.DeepEqual(expectedV, v) {
-			equal = false
-			break
-		}
-	}
-
-	if !equal {
-		t.Errorf("Expected %+v got %+v", expected, e.Inventory.Items())
-	}
-}
-
-func Test_populateInventory_SysConfigError(t *testing.T) {
-	i, err := integration.New("test", "1.0.0")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
-
-	e, err := i.Entity("test", "instance")
-	if err != nil {
-		t.Errorf("Unexpected error %s", err.Error())
-		t.FailNow()
-	}
-
-	conn, mock := CreateMockSQL(t)
-
-	engineEdition := 3
-
-	// SPConfig expect
-	spConfigRows := sqlmock.NewRows([]string{"name", "minimum", "maximum", "config_value", "run_value"}).
-		AddRow("allow polybase export", 0, 1, 0, 0).
-		AddRow("allow updates", 0, 1, 0, 0)
-	mock.ExpectQuery(spConfigQuery).WillReturnRows(spConfigRows)
-
-	// sys.configurations expect
-	mock.ExpectQuery(sysConfigQuery).WillReturnError(errors.New("error"))
-
-	PopulateInventory(e, conn, engineEdition)
-
-	// expected inventory.Items map to be set
-	expected := map[string]inventory.Item{
-		"allow polybase export/run_value": {"value": 0},
-		"allow updates/run_value":         {"value": 0},
-	}
-
-	// reflect.DeepEqual did not work on comparing Items maps so did a manual comparison
-	equal := true
-	for k, expectedV := range expected {
-		v, ok := e.Inventory.Item(k)
-		if !ok {
-			equal = false
-			break
-		}
-
-		if !reflect.DeepEqual(expectedV, v) {
-			equal = false
-			break
-		}
-	}
-
-	if !equal {
-		t.Errorf("Expected %+v got %+v", expected, e.Inventory.Items())
+		runTestPopulateInventory(t, tt)
 	}
 }

--- a/src/metrics/database_metric_definitions.go
+++ b/src/metrics/database_metric_definitions.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	// databasePlaceHolder placeholder for Database name in a query
-	databasePlaceHolder      = "%DATABASE%"
+	// databasePlaceholder placeholder for Database name in a query
+	databasePlaceholder      = "%DATABASE%"
 	memoryUtilizationQuery   = "SELECT top 1 DB_NAME() AS db_name, avg_memory_usage_percent AS memory_utilization FROM sys.dm_db_resource_stats ORDER BY end_time DESC;"
 	totalPhysicalMemoryQuery = "SELECT DB_NAME() AS db_name, (process_memory_limit_mb * 1024 * 1024) AS total_physical_memory FROM sys.dm_os_job_object;"
 )
@@ -34,7 +34,7 @@ type AvailablePhysicalMemoryModel struct {
 // databasePlaceHolder is present
 func dbNameReplace(dbName string) QueryModifier {
 	return func(query string) string {
-		return strings.Replace(query, databasePlaceHolder, dbName, -1)
+		return strings.ReplaceAll(query, databasePlaceholder, dbName)
 	}
 }
 
@@ -166,7 +166,7 @@ var specificDatabaseDefinitions = []*QueryDefinition{
 		max(reserved_space_kb) * 1024 AS reserved_space,
 		max(reserved_space_not_used_kb) * 1024 AS reserved_space_not_used
 		FROM reserved_space
-		GROUP BY db_name`, databasePlaceHolder),
+		GROUP BY db_name`, databasePlaceholder),
 		dataModels: &[]struct {
 			database.DataModel
 			ReservedSpace        float64 `db:"reserved_space" metric_name:"pageFileTotal" source_type:"gauge"`

--- a/src/metrics/database_metric_definitions.go
+++ b/src/metrics/database_metric_definitions.go
@@ -50,24 +50,7 @@ var databaseDefinitions = []*QueryDefinition{
 	},
 }
 
-// databaseBufferDefinitions definitions for Database Queries
-var databaseBufferDefinitions = []*QueryDefinition{
-	{
-		query: `SELECT DB_NAME(database_id) AS db_name, buffer_pool_size * (8*1024) AS buffer_pool_size
-		FROM ( SELECT database_id, COUNT_BIG(*) AS buffer_pool_size FROM sys.dm_os_buffer_descriptors a WITH (NOLOCK)
-		INNER JOIN sys.sysdatabases b WITH (NOLOCK) ON b.dbid=a.database_id 
-		WHERE b.dbid in (SELECT dbid FROM sys.sysdatabases WITH (NOLOCK)
-		WHERE name NOT IN ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
-		UNION ALL SELECT 32767) GROUP BY database_id) a`,
-		dataModels: &[]struct {
-			database.DataModel
-			IOStalls int `db:"buffer_pool_size" metric_name:"bufferpool.sizePerDatabaseInBytes" source_type:"gauge"`
-		}{},
-	},
-}
-
-//nolint:all
-var specificDatabaseDefinitionsForAzureSQLDatabase = []*QueryDefinition{
+var databaseDefinitionsForAzureSQLDatabase = []*QueryDefinition{
 	{
 		query: `
 			SELECT 
@@ -98,6 +81,25 @@ var specificDatabaseDefinitionsForAzureSQLDatabase = []*QueryDefinition{
 			IOStalls int `db:"io_stalls" metric_name:"io.stallInMilliseconds" source_type:"gauge"`
 		}{},
 	},
+}
+
+// databaseBufferDefinitions definitions for Database Queries
+var databaseBufferDefinitions = []*QueryDefinition{
+	{
+		query: `SELECT DB_NAME(database_id) AS db_name, buffer_pool_size * (8*1024) AS buffer_pool_size
+		FROM ( SELECT database_id, COUNT_BIG(*) AS buffer_pool_size FROM sys.dm_os_buffer_descriptors a WITH (NOLOCK)
+		INNER JOIN sys.sysdatabases b WITH (NOLOCK) ON b.dbid=a.database_id 
+		WHERE b.dbid in (SELECT dbid FROM sys.sysdatabases WITH (NOLOCK)
+		WHERE name NOT IN ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
+		UNION ALL SELECT 32767) GROUP BY database_id) a`,
+		dataModels: &[]struct {
+			database.DataModel
+			IOStalls int `db:"buffer_pool_size" metric_name:"bufferpool.sizePerDatabaseInBytes" source_type:"gauge"`
+		}{},
+	},
+}
+
+var databaseBufferDefinitionsForAzureSQLDatabase = []*QueryDefinition{
 	{
 		query: `
 			SELECT 
@@ -109,22 +111,6 @@ var specificDatabaseDefinitionsForAzureSQLDatabase = []*QueryDefinition{
 		dataModels: &[]struct {
 			database.DataModel
 			BufferPoolSize int `db:"buffer_pool_size" metric_name:"bufferpool.sizePerDatabaseInBytes" source_type:"gauge"`
-		}{},
-	},
-	{
-		query: `
-			SELECT
-				DB_NAME() AS db_name,
-				sum(a.total_pages) * 8.0 * 1024 AS reserved_space,
-				(sum(a.total_pages)*8.0 - sum(a.used_pages)*8.0) * 1024 AS reserved_space_not_used
-			FROM sys.partitions p with (nolock)
-			INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
-			LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id
-		`,
-		dataModels: &[]struct {
-			database.DataModel
-			ReservedSpace        float64 `db:"reserved_space" metric_name:"pageFileTotal" source_type:"gauge"`
-			ReservedSpaceNotUsed float64 `db:"reserved_space_not_used" metric_name:"pageFileAvailable" source_type:"gauge"`
 		}{},
 	},
 }
@@ -155,4 +141,68 @@ var specificDatabaseDefinitions = []*QueryDefinition{
 			ReservedSpaceNotUsed float64 `db:"reserved_space_not_used" metric_name:"pageFileAvailable" source_type:"gauge"`
 		}{},
 	},
+}
+
+var specificDatabaseDefinitionsForAzureSQLDatabase = []*QueryDefinition{
+	{
+		query: `
+			SELECT
+				DB_NAME() AS db_name,
+				sum(a.total_pages) * 8.0 * 1024 AS reserved_space,
+				(sum(a.total_pages)*8.0 - sum(a.used_pages)*8.0) * 1024 AS reserved_space_not_used
+			FROM sys.partitions p with (nolock)
+			INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
+			LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id
+		`,
+		dataModels: &[]struct {
+			database.DataModel
+			ReservedSpace        float64 `db:"reserved_space" metric_name:"pageFileTotal" source_type:"gauge"`
+			ReservedSpaceNotUsed float64 `db:"reserved_space_not_used" metric_name:"pageFileAvailable" source_type:"gauge"`
+		}{},
+	},
+}
+
+// engineSet is a generic struct that acts as a "bucket" for holding
+// the default and Azure-specific implementations for a given resource.
+type engineSet[T any] struct {
+	Default T
+	Azure   T
+}
+
+// Select returns the correct implementation from the set based on the engine edition.
+func (s engineSet[T]) Select(engineEdition int) T {
+	if engineEdition == database.AzureSQLDatabaseEngineEditionNumber {
+		return s.Azure
+	}
+	return s.Default
+}
+
+// Bucket for standard database query definitions
+var databaseDefinitionSet = engineSet[[]*QueryDefinition]{
+	Default: databaseDefinitions,
+	Azure:   databaseDefinitionsForAzureSQLDatabase,
+}
+
+// Bucket for buffer query definitions
+var databaseBufferDefinitionSet = engineSet[[]*QueryDefinition]{
+	Default: databaseBufferDefinitions,
+	Azure:   databaseBufferDefinitionsForAzureSQLDatabase,
+}
+
+// Bucket for specific database query definitions
+var specificDatabaseDefinitionSet = engineSet[[]*QueryDefinition]{
+	Default: specificDatabaseDefinitions,
+	Azure:   specificDatabaseDefinitionsForAzureSQLDatabase,
+}
+
+func getDatabaseDefinitions(engineEdition int) []*QueryDefinition {
+	return databaseDefinitionSet.Select(engineEdition)
+}
+
+func getDatabaseBufferDefinitions(engineEdition int) []*QueryDefinition {
+	return databaseBufferDefinitionSet.Select(engineEdition)
+}
+
+func getSpecificDatabaseDefinitions(engineEdition int) []*QueryDefinition {
+	return specificDatabaseDefinitionSet.Select(engineEdition)
 }

--- a/src/metrics/database_metric_definitions.go
+++ b/src/metrics/database_metric_definitions.go
@@ -66,6 +66,69 @@ var databaseBufferDefinitions = []*QueryDefinition{
 	},
 }
 
+//nolint:all
+var specificDatabaseDefinitionsForAzureSQLDatabase = []*QueryDefinition{
+	{
+		query: `
+			SELECT 
+			    sd.name AS db_name,
+			    spc.cntr_value AS log_growth
+			FROM sys.dm_os_performance_counters spc
+			INNER JOIN sys.databases sd 
+			    ON sd.physical_database_name = spc.instance_name
+			WHERE spc.counter_name = 'Log Growths'
+			    AND spc.object_name LIKE '%:Databases%'
+			    AND sd.database_id = DB_ID()
+		`,
+		dataModels: &[]struct {
+			database.DataModel
+			LogGrowth int `db:"log_growth" metric_name:"log.transactionGrowth" source_type:"gauge"`
+		}{},
+	},
+	{
+		query: `		
+			SELECT
+			    DB_NAME() AS db_name,
+			    SUM(io_stall) AS io_stalls
+			FROM sys.dm_io_virtual_file_stats(NULL, NULL)
+			WHERE database_id = DB_ID()
+		`,
+		dataModels: &[]struct {
+			database.DataModel
+			IOStalls int `db:"io_stalls" metric_name:"io.stallInMilliseconds" source_type:"gauge"`
+		}{},
+	},
+	{
+		query: `
+			SELECT 
+			    DB_NAME() AS db_name, 
+			    COUNT_BIG(*) * (8 * 1024) AS buffer_pool_size
+			FROM sys.dm_os_buffer_descriptors WITH (NOLOCK) 
+			WHERE database_id = DB_ID()
+		`,
+		dataModels: &[]struct {
+			database.DataModel
+			BufferPoolSize int `db:"buffer_pool_size" metric_name:"bufferpool.sizePerDatabaseInBytes" source_type:"gauge"`
+		}{},
+	},
+	{
+		query: `
+			SELECT
+				DB_NAME() AS db_name,
+				sum(a.total_pages) * 8.0 * 1024 AS reserved_space,
+				(sum(a.total_pages)*8.0 - sum(a.used_pages)*8.0) * 1024 AS reserved_space_not_used
+			FROM sys.partitions p with (nolock)
+			INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
+			LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id
+		`,
+		dataModels: &[]struct {
+			database.DataModel
+			ReservedSpace        float64 `db:"reserved_space" metric_name:"pageFileTotal" source_type:"gauge"`
+			ReservedSpaceNotUsed float64 `db:"reserved_space_not_used" metric_name:"pageFileAvailable" source_type:"gauge"`
+		}{},
+	},
+}
+
 var specificDatabaseDefinitions = []*QueryDefinition{
 	{
 		query: fmt.Sprintf(`USE "%s"

--- a/src/metrics/database_metric_definitions_test.go
+++ b/src/metrics/database_metric_definitions_test.go
@@ -8,7 +8,7 @@ import (
 func Test_dbNameReplace(t *testing.T) {
 
 	dbName, format := "master", "use %s select * from %s"
-	query := fmt.Sprintf(format, databasePlaceHolder, databasePlaceHolder)
+	query := fmt.Sprintf(format, databasePlaceholder, databasePlaceholder)
 	expected := fmt.Sprintf(format, dbName, dbName)
 
 	modifier := dbNameReplace(dbName)

--- a/src/metrics/instance_metric_definitions.go
+++ b/src/metrics/instance_metric_definitions.go
@@ -160,7 +160,7 @@ type waitTimeModel struct {
 	WaitCount *int64  `db:"waiting_tasks_count"`
 }
 
-var diskMetricInBytesDefination = []*QueryDefinition{
+var diskMetricInBytesDefinition = []*QueryDefinition{
 	{
 		query: `SELECT Sum(total_bytes) AS total_disk_space FROM (
 			SELECT DISTINCT

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -50,6 +50,7 @@ const (
 )
 
 // PopulateInstanceMetrics creates instance-level metrics
+// The below function has too many if's which is needed , so ignoring the golint error by adding below linter directive.
 //
 //nolint:gocyclo
 func PopulateInstanceMetrics(instanceEntity *integration.Entity, connection *connection.SQLConnection, arguments args.ArgumentList, engineEdition int) {
@@ -69,7 +70,7 @@ func PopulateInstanceMetrics(instanceEntity *integration.Entity, connection *con
 
 	for _, queryDef := range collectionList {
 		models := queryDef.GetDataModels()
-		if common.ShouldSkipQueryForEngineEdition(engineEdition, queryDef.GetQuery()) {
+		if common.SkipQueryForEngineEdition(engineEdition, queryDef.GetQuery()) {
 			log.Debug("Skipping query '%s' for unsupported engine edition %d", queryDef.GetQuery(), engineEdition)
 			continue
 		}

--- a/src/mssql.go
+++ b/src/mssql.go
@@ -87,7 +87,7 @@ func main() {
 
 	// Metric collection
 	if args.HasMetrics() {
-		if err := metrics.PopulateDatabaseMetrics(i, instanceEntity.Metadata.Name, con, args); err != nil {
+		if err := metrics.PopulateDatabaseMetrics(i, instanceEntity.Metadata.Name, con, args, engineEdition); err != nil {
 			log.Error("Error collecting metrics for databases: %s", err.Error())
 		}
 

--- a/src/mssql.go
+++ b/src/mssql.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/newrelic/nri-mssql/src/args"
 	"github.com/newrelic/nri-mssql/src/connection"
+	"github.com/newrelic/nri-mssql/src/database"
 	"github.com/newrelic/nri-mssql/src/instance"
 	"github.com/newrelic/nri-mssql/src/inventory"
 	"github.com/newrelic/nri-mssql/src/metrics"
@@ -72,9 +73,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Get EngineEdition
+	engineEdition := 0 // Default to 0 (Unknown)
+	engineEdition, err = database.GetEngineEdition(con)
+	if err != nil {
+		log.Debug("Failed to get engine edition: %v", err)
+	}
+
 	// Inventory collection
 	if args.HasInventory() {
-		inventory.PopulateInventory(instanceEntity, con)
+		inventory.PopulateInventory(instanceEntity, con, engineEdition)
 	}
 
 	// Metric collection
@@ -83,7 +91,7 @@ func main() {
 			log.Error("Error collecting metrics for databases: %s", err.Error())
 		}
 
-		metrics.PopulateInstanceMetrics(instanceEntity, con, args)
+		metrics.PopulateInstanceMetrics(instanceEntity, con, args, engineEdition)
 	}
 
 	// Close connection when done

--- a/src/testdata/azureSQLDatabaseMetrics.json.golden
+++ b/src/testdata/azureSQLDatabaseMetrics.json.golden
@@ -36,7 +36,10 @@
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
+                    "io.stallInMilliseconds": 0,
                     "log.transactionGrowth": 0,
+                    "pageFileTotal": 0,
+                    "pageFileAvailable": 0,
                     "reportingEndpoint": "testhost"
                 }
             ],
@@ -66,7 +69,10 @@
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
+                    "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
+                    "pageFileTotal": 1,
+                    "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"
                 }
             ],

--- a/src/testdata/azureSQLDatabaseMetricsWithoutMemoryMetrics.json.golden
+++ b/src/testdata/azureSQLDatabaseMetricsWithoutMemoryMetrics.json.golden
@@ -30,18 +30,13 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 0,
                     "displayName": "db-1",
                     "entityName": "ms-database:db-1",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 0,
                     "log.transactionGrowth": 0,
-                    "memoryUtilization": 31.18,
-                    "memoryTotal": 2097152,
-                    "memoryAvailable": 1443260.0063999998, 
                     "pageFileTotal": 0,
                     "pageFileAvailable": 0,
                     "reportingEndpoint": "testhost"
@@ -67,18 +62,13 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 1,
                     "displayName": "db-2",
                     "entityName": "ms-database:db-2",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
-                    "memoryUtilization": 31.18,
-                    "memoryTotal": 2097152,
-                    "memoryAvailable": 1443260.0063999998,
                     "pageFileTotal": 1,
                     "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"

--- a/src/testdata/databasePartialMemoryMetrics.json.golden
+++ b/src/testdata/databasePartialMemoryMetrics.json.golden
@@ -30,18 +30,14 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 0,
                     "displayName": "db-1",
                     "entityName": "ms-database:db-1",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 0,
                     "log.transactionGrowth": 0,
                     "memoryUtilization": 31.18,
-                    "memoryTotal": 2097152,
-                    "memoryAvailable": 1443260.0063999998, 
                     "pageFileTotal": 0,
                     "pageFileAvailable": 0,
                     "reportingEndpoint": "testhost"
@@ -67,18 +63,14 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 1,
                     "displayName": "db-2",
                     "entityName": "ms-database:db-2",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
                     "memoryUtilization": 31.18,
-                    "memoryTotal": 2097152,
-                    "memoryAvailable": 1443260.0063999998,
                     "pageFileTotal": 1,
                     "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"

--- a/src/testdata/nonEmptyMetrics.json.golden
+++ b/src/testdata/nonEmptyMetrics.json.golden
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "entity": {
+        "id_attributes": [],
+        "name": "test",
+        "type": "instance"
+      },
+      "events": [],
+      "inventory": {},
+      "metrics": [
+        {
+          "displayName": "test",
+          "entityName": "instance:test",
+          "event_type": "MssqlInstanceSample",
+          "host": "testhost",
+          "system.bufferPoolHitPercent": 95.5
+        }
+      ]
+    }
+  ],
+  "integration_version": "1.0.0",
+  "name": "test",
+  "protocol_version": "3"
+}

--- a/src/testdata/partialAzureSQLDatabaseMetrics.json.golden
+++ b/src/testdata/partialAzureSQLDatabaseMetrics.json.golden
@@ -63,8 +63,12 @@
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
+                    "maxDiskSizeInBytes": 104857600,
                     "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
+                    "memoryUtilization": 31.18,
+                    "memoryTotal": 2097152,
+                    "memoryAvailable": 1443260.0063999998,
                     "pageFileTotal": 1,
                     "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"

--- a/src/testdata/partialAzureSQLDatabaseMetrics.json.golden
+++ b/src/testdata/partialAzureSQLDatabaseMetrics.json.golden
@@ -30,13 +30,11 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 0,
                     "displayName": "db-1",
                     "entityName": "ms-database:db-1",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
-                    "log.transactionGrowth": 0,
                     "reportingEndpoint": "testhost"
                 }
             ],
@@ -60,13 +58,15 @@
             },
             "metrics": [
                 {
-                    "bufferpool.sizePerDatabaseInBytes": 1,
                     "displayName": "db-2",
                     "entityName": "ms-database:db-2",
                     "event_type": "MssqlDatabaseSample",
                     "host": "testhost",
                     "instance": "MSSQL",
+                    "io.stallInMilliseconds": 1,
                     "log.transactionGrowth": 1,
+                    "pageFileTotal": 1,
+                    "pageFileAvailable": 1,
                     "reportingEndpoint": "testhost"
                 }
             ],


### PR DESCRIPTION
### Description

- Add regular monitoring support for azure sql database

High level changes in this PR

- Add functions that Identify the server being monitored as an azure sql database (#222)
- Skip running unsupported sql queries for azure sql database (#226)
- Add new database definition queries for azure sql database (#227)
- Create new connections to each database in case of azure sql database (#228)
- Populate memory, disk metrics and inventory for azure sql database (#229)

Docs [forked repo PR](https://github.com/sairaj18/docs-website/pull/1) to support Azure SQL Database. These changes will be commited to the original docs-website repo as part of this [PR](https://github.com/newrelic/docs-website/pull/20674)

### Testing Details: 

Did a manual install of `nri-mssql` integration on an Azure Windows VM and replaced the binary with a new binary build from this branch. All the telemetry was coming correctly. Compared Azure SQL Database vs Self hosted MSSQL server ingested samples - `MssqlInstanceSample` , `MssqlWaitSample` , `MssqlDatabaseSample`, `Invetory`. Adding the json's below for reference.

Commands used to build the windows binary
```shell
 $Env:GOOS = "windows"
 $Env:GOARCH="amd64"
 go build -v -o ./bin/nri-mssql.exe ./src/
``` 

[azure-sql-database.json](https://github.com/user-attachments/files/20794159/azure-sql-database.json)
[sql-on-vm.json](https://github.com/user-attachments/files/20794162/sql-on-vm.json)


![image](https://github.com/user-attachments/assets/e448cbb9-52ed-4a42-bfb6-915d71e540e1)
