### PR TITLE
Fixing io stall to use the right values

### DIFF
--- a/src/metrics/database_metric_definitions.go
+++ b/src/metrics/database_metric_definitions.go
@@ -58,7 +58,7 @@ var databaseDefinitions = []*QueryDefinition{
 	}, {
 		query: `select
 		DB_NAME(database_id) AS db_name,
-		SUM(io_stall_write_ms) + SUM(num_of_writes) as io_stalls
+		SUM(io_stall) AS io_stalls
 		FROM sys.dm_io_virtual_file_stats(null,null)
     WHERE DB_NAME(database_id) NOT IN ('master', 'tempdb', 'msdb', 'model', 'rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
 		GROUP BY database_id`,


### PR DESCRIPTION
This PR corrects the IO stall calculation in the database performance query.
he previous implementation incorrectly added `io_stall_write_ms (milliseconds)` and `num_of_writes (count)`, which mixed incompatible units and produced meaningless results.
The fix uses `SUM(io_stall)` instead, which properly measures total I/O wait time in consistent millisecond units. The io_stall column already aggregates all I/O stall time (reads and writes) and provides an accurate measure of I/O performance impact