### PR TITLE
fix: diskInBytes query supports case sensitive collation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+- Fixed the query for `instance.diskInBytes` to support instances with case-sensitive collation
+
 ## v2.19.0 - 2025-06-24
 
 ### 🚀 Enhancements

--- a/src/metrics/instance_metric_definitions.go
+++ b/src/metrics/instance_metric_definitions.go
@@ -190,7 +190,7 @@ var diskMetricInBytesDefinition = []*QueryDefinition{
 			dovs.available_bytes available_bytes,
 			dovs.total_bytes total_bytes
 			FROM sys.master_files mf WITH (nolock)
-			CROSS apply sys.Dm_os_volume_stats(mf.database_id, mf.file_id) dovs
+			CROSS apply sys.dm_os_volume_stats(mf.database_id, mf.file_id) dovs
 			) drives`,
 		dataModels: &[]struct {
 			TotalDiskSpace *int64 `db:"total_disk_space" metric_name:"instance.diskInBytes" source_type:"gauge"`


### PR DESCRIPTION
With case sensitive collation enabled.
The query with `ys.Dm_os_volume_stats(mf.database_id, mf.file_id)` fails to work.

<img width="677" alt="Screenshot 2025-07-01 at 10 25 13 AM" src="https://github.com/user-attachments/assets/91e77d65-ddff-41c2-891f-5593d21dd7cb" />

Switched the query to use `ys.dm_os_volume_stats(mf.database_id, mf.file_id)` and this now works.
Every other query in the file already does this, so this query has an Uppercase table name is weird.

<img width="669" alt="Screenshot 2025-07-01 at 10 25 33 AM" src="https://github.com/user-attachments/assets/f32b5b3e-e883-467f-815d-2c1510e6c112" />
