### PR TITLE
Converted GETUTCDATETIME() to SYSDATETIME()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### enhancements
+- Switched to using SYSDATETIME() for correct time comparisons where system date is not set to UTC
+
+
 ## v2.20.0 - 2025-07-09
 
 ### 🚀 Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### enhancements
+### bugfix
 - Switched to using SYSDATETIME() for correct time comparisons where system date is not set to UTC
-
 
 ## v2.20.0 - 2025-07-09
 

--- a/src/queryanalysis/config/query_config.go
+++ b/src/queryanalysis/config/query_config.go
@@ -19,7 +19,7 @@ var Queries = []models.QueryDetailsDto{
 						sys.dm_exec_query_stats qs
 					WHERE 
 						qs.execution_count > 0
-						AND qs.last_execution_time >= DATEADD(SECOND, -@IntervalSeconds, GETUTCDATE())
+						AND qs.last_execution_time >= DATEADD(SECOND, -@IntervalSeconds, SYSDATETIME())
 						AND qs.sql_handle IS NOT NULL
 				),
 				QueryStats AS (
@@ -317,7 +317,7 @@ TopPlans AS (
     CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
     CROSS APPLY sys.dm_exec_query_plan(qs.plan_handle) AS qp
 	WHERE qs.query_hash IN (SELECT QueryId FROM @QueryIdTable)
-    AND qs.last_execution_time BETWEEN DATEADD(SECOND, -@IntervalSeconds, GETUTCDATE()) AND GETUTCDATE() 
+	AND qs.last_execution_time BETWEEN DATEADD(SECOND, -@IntervalSeconds, SYSDATETIME()) AND SYSDATETIME()
     AND COALESCE((qs.total_elapsed_time / NULLIF(qs.execution_count, 0)) / 1000, 0) > @ElapsedTimeThreshold
     ORDER BY avg_elapsed_time_ms DESC
 ),

--- a/src/queryanalysis/config/query_config.go
+++ b/src/queryanalysis/config/query_config.go
@@ -191,7 +191,7 @@ var Queries = []models.QueryDetailsDto{
 						  0 
 					  END AS wait_event_count,
 					  qsq.query_hash AS query_id,
-					  GETUTCDATE() AS collection_timestamp,
+					  SYSDATETIME() AS collection_timestamp,
 					  ''' + @dbName + ''' AS database_name
 					FROM 
 					  sys.query_store_wait_stats ws


### PR DESCRIPTION
This PR corrects a critical time zone issue where MSSQLTopSlowQueries and ExecutionPlanQuery were using GETUTCDATE() to filter against qs.last_execution_time, which is stored in server local time. The mismatch caused queries to return no recent data in environments where local time is ahead of UTC.

Replace GETUTCDATE() with SYSDATETIME() in both query time filters to align with the sys.dm_exec_query_stats DMV's local time storage

Integration tests running against SQL Server instances in different time zones will validate that recent slow queries and execution plans are now properly collected within the specified interval window. No additional tests are needed IMO.