### PR TITLE
security: add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/automated_release.yaml
+++ b/.github/workflows/automated_release.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "30 9 * * 2"
 
+
+permissions:
+  contents: read
+
 jobs:
   release_management:
     uses: newrelic/coreint-automation/.github/workflows/reusable_release_automation.yaml@v3

--- a/.github/workflows/on_prerelease.yaml
+++ b/.github/workflows/on_prerelease.yaml
@@ -7,6 +7,10 @@ on:
     tags:
       - 'v*'
 
+
+permissions:
+  contents: read
+
 jobs:
   pre-release:
     uses: newrelic/coreint-automation/.github/workflows/reusable_pre_release.yaml@v3

--- a/.github/workflows/on_push_pr.yaml
+++ b/.github/workflows/on_push_pr.yaml
@@ -8,6 +8,10 @@ on:
       - renovate/**
   pull_request:
 
+
+permissions:
+  contents: read
+
 jobs:
   push-pr:
     uses: newrelic/coreint-automation/.github/workflows/reusable_push_pr.yaml@v3

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -7,6 +7,10 @@ on:
     tags:
       - 'v*'
 
+
+permissions:
+  contents: read
+
 jobs:
   release:
     uses: newrelic/coreint-automation/.github/workflows/reusable_on_release.yaml@v3

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -6,6 +6,10 @@ on:
   push:
   workflow_dispatch:
 
+
+permissions:
+  contents: read
+
 jobs:
   repolinter:
     uses: newrelic/coreint-automation/.github/workflows/reusable_repolinter.yaml@v3

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+
+permissions:
+  contents: read
+
 jobs:
   security:
     uses: newrelic/coreint-automation/.github/workflows/reusable_security.yaml@v3


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to all workflow files missing a permissions block
- Follows the principle of least privilege for GitHub Actions tokens
- Resolves CodeQL alert `actions/missing-workflow-permissions` ([NR-560126](https://new-relic.atlassian.net/browse/NR-560126))

## Test plan
- [ ] Verify CI workflows still pass with the new permissions block
- [ ] Confirm CodeQL alert is resolved after merge

[NR-560126]: https://new-relic.atlassian.net/browse/NR-560126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ