### PR TITLE
fix(qpm): remove Azure SQL version cap to support engine v17+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### Bug fixes
-- Removed the hardcoded upper-bound version check on Azure SQL in qpm validation so engine v17.x reported by Azure SQL Managed Instance (Always-up-to-date update policy) is accepted; the Azure check now mirrors the on-prem pattern of a lower-bound only (NR-559155)
+### bug fixes
+- Removed the hardcoded upper-bound version check on Azure SQL in qpm validation so engine v17.x reported by Azure SQL Managed Instance (Always-up-to-date update policy) is accepted
 
 ## v2.30.0 - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### 🛠 Bug fixes
+### 🐞 Bug fixes
 - Removed hardcoded upper-bound version check `version.Major <= 16` for Azure SQL in QPM
   validation. Azure SQL Managed Instance running engine v17.x (rolled out via the
   Always-up-to-date update policy) was previously rejected from Query Store collection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### Fixed
+### 🐞 Bug fixes
 - Removed hardcoded upper-bound version check `version.Major <= 16` for Azure SQL in QPM
   validation. Azure SQL Managed Instance running engine v17.x (rolled out via the
   Always-up-to-date update policy) was previously rejected from Query Store collection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,8 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### 🐞 Bug fixes
-- Removed hardcoded upper-bound version check `version.Major <= 16` for Azure SQL in QPM
-  validation. Azure SQL Managed Instance running engine v17.x (rolled out via the
-  Always-up-to-date update policy) was previously rejected from Query Store collection.
-  The Azure check now mirrors the on-prem pattern of a lower-bound only (`>= 12`). [NR-559155]
+### Bug fixes
+- Removed the hardcoded upper-bound version check on Azure SQL in qpm validation so engine v17.x reported by Azure SQL Managed Instance (Always-up-to-date update policy) is accepted; the Azure check now mirrors the on-prem pattern of a lower-bound only (NR-559155)
 
 ## v2.30.0 - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### 🛠 Bug fixes
+- Removed hardcoded upper-bound version check `version.Major <= 16` for Azure SQL in QPM
+  validation. Azure SQL Managed Instance running engine v17.x (rolled out via the
+  Always-up-to-date update policy) was previously rejected from Query Store collection.
+  The Azure check now mirrors the on-prem pattern of a lower-bound only (`>= 12`). [NR-559155]
+
 ### Security
 - Updated golang to v1.25.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### 🐞 Bug fixes
+### Bug fixes
 - Removed hardcoded upper-bound version check `version.Major <= 16` for Azure SQL in QPM
   validation. Azure SQL Managed Instance running engine v17.x (rolled out via the
   Always-up-to-date update policy) was previously rejected from Query Store collection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### bug fixes
+### bugfix
 - Removed the hardcoded upper-bound version check on Azure SQL in qpm validation so engine v17.x reported by Azure SQL Managed Instance (Always-up-to-date update policy) is accepted
 
 ## v2.30.0 - 2026-05-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### Bug fixes
+### Fixed
 - Removed hardcoded upper-bound version check `version.Major <= 16` for Azure SQL in QPM
   validation. Azure SQL Managed Instance running engine v17.x (rolled out via the
   Always-up-to-date update policy) was previously rejected from Query Store collection.

--- a/src/queryanalysis/validation/sql_server_version.go
+++ b/src/queryanalysis/validation/sql_server_version.go
@@ -16,9 +16,8 @@ const (
 	getSQLServerVersionQuery     = "SELECT @@VERSION"
 	firstSupportedVersion        = 14
 	dmvOnlyFirstSupportedVersion = 13 // SQL Server 2016 (AT TIME ZONE, STRING_SPLIT)
-	// Defines the supported version range for Azure SQL Server in the cloud, from version 12 to 16.
+	// Azure SQL is Microsoft-managed and forward-compatible; require >= 12, no upper bound.
 	azureFirstSupportedVersion = 12
-	azureLastSupportedVersion  = 16
 )
 
 var (
@@ -64,9 +63,8 @@ func checkSQLServerVersion(sqlConnection *connection.SQLConnection, isDMVOnlyMod
 	isAzure := strings.Contains(strings.ToLower(serverVersion), "azure")
 
 	if isAzure {
-		// Azure: Keep existing range (12-16) for both modes
-		return version.Major >= azureFirstSupportedVersion &&
-			version.Major <= azureLastSupportedVersion, nil
+		// Azure: only enforce a lower bound; matches on-prem pattern.
+		return version.Major >= azureFirstSupportedVersion, nil
 	}
 
 	// On-premises SQL Server

--- a/src/queryanalysis/validation/sql_server_version_test.go
+++ b/src/queryanalysis/validation/sql_server_version_test.go
@@ -28,10 +28,14 @@ func TestCheckSQLServerVersionforAzure(t *testing.T) {
 		version  string
 		expected bool
 	}{
-		{"AzureSupportedVersion", "Microsoft SQL Azure (RTM) - 12.0.2000.8", true},
-		{"AzureUnsupportedVersion", "Microsoft SQL azure (RTM) - 11.0.2000.7", false},
-		{"AzureUnsupportedVersion", "Microsoft SQL (RTM) - 12.0.2000.8", false},
-		{"AzureUnsupportedVersion", "Microsoft SQL Azure (RTM) - 17.0.2000.8", false},
+		{"AzureSupportedVersion_v12", "Microsoft SQL Azure (RTM) - 12.0.2000.8", true},
+		{"AzureUnsupportedVersion_v11", "Microsoft SQL azure (RTM) - 11.0.2000.7", false},
+		{"NotAzure_v12_ButLowerOnPremFails", "Microsoft SQL (RTM) - 12.0.2000.8", false},
+		// Azure SQL MI rolls v17 via the Always-up-to-date update policy. Used to be rejected
+		// by a hardcoded `<= 16` cap; now accepted because the cap was removed (NR-559155).
+		{"AzureSupportedVersion_v17", "Microsoft SQL Azure (RTM) - 17.0.2000.8", true},
+		// Future-proofing: removing the cap means Azure v18+ also passes without code change.
+		{"AzureSupportedVersion_v18_FutureProof", "Microsoft SQL Azure (RTM) - 18.0.0.0", true},
 	}
 
 	for _, tt := range tests {
@@ -264,6 +268,30 @@ func TestCheckSqlServerVersion_Azure_DMVOnlyMode(t *testing.T) {
 			isDMVOnlyMode: true,
 			expected:      true,
 			description:   "Azure SQL v16 should be accepted in DMV-only mode",
+		},
+		// NR-559155: cap removal — Azure v17 (rolled to MI via Always-up-to-date)
+		// must be accepted in both modes. Previously rejected.
+		{
+			name:          "AzureSQL_v17_QueryStoreMode",
+			version:       "Microsoft SQL Azure (RTM) - 17.0.4040.1",
+			isDMVOnlyMode: false,
+			expected:      true,
+			description:   "Azure SQL v17 should be accepted in Query Store mode (NR-559155)",
+		},
+		{
+			name:          "AzureSQL_v17_DMVOnlyMode",
+			version:       "Microsoft SQL Azure (RTM) - 17.0.4040.1",
+			isDMVOnlyMode: true,
+			expected:      true,
+			description:   "Azure SQL v17 should be accepted in DMV-only mode (NR-559155)",
+		},
+		// Future-proofing: cap removal means v18+ passes without further code change.
+		{
+			name:          "AzureSQL_v18_FutureProof",
+			version:       "Microsoft SQL Azure (RTM) - 18.0.0.0",
+			isDMVOnlyMode: false,
+			expected:      true,
+			description:   "Azure SQL v18+ should be accepted (cap removed)",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Remove hardcoded `version.Major <= 16` upper-bound check on the Azure SQL code path in QPM validation.
- The Azure check now requires only `>= azureFirstSupportedVersion (12)`, matching the on-prem branch pattern.
- Unblocks Azure SQL Managed Instance running engine v17.x (rolled out via the Always-up-to-date update policy).

## Why remove rather than bump

Azure SQL is a Microsoft-managed PaaS — engine versions only move forward, and Query Store has a backward-compat contract since v12. A hardcoded upper bound is structurally fragile: every new major version triggers this exact bug. Bumping just defers it; removing it eliminates the recurrence pattern. The on-prem branch already operates without an upper bound, so this aligns conventions across both code paths.

A detailed change document with empirical validation results, NR UI evidence, and reviewer reproduction steps is attached as the first comment.

## Test plan

- [x] `go test ./src/queryanalysis/validation/... -run "TestCheckSQLServerVersionforAzure|TestCheckSqlServerVersion_Azure_DMVOnlyMode" -v` — all subtests PASS, including new v17 / v18 acceptance cases.
- [x] `go test ./...` — full project test suite green.
- [x] Integration smoke test against SQL Server 2025 (engine v17.0.4040.1) in Docker — 6 event types populated (`MssqlInstanceSample`, `MssqlDatabaseSample`, `MssqlWaitSample`, `MSSQLTopSlowQueries`, `MSSQLQueryExecutionPlans`, `MSSQLWaitTimeAnalysis`), no `Unsupported SQL Server version` log line, no T-SQL errors.
- [ ] NR UI screenshots from account 3516917 — see attached change doc §5.3 for NRQL queries; screenshots will be added inline.

Fixes [NR-559155](https://new-relic.atlassian.net/browse/NR-559155).

[NR-559155]: https://new-relic.atlassian.net/browse/NR-559155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ