### PR TITLE
fix(security): prevent SQL injection via database name in specificDatabaseDefinitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### security
+- Fixed second-order SQL injection in `specificDatabaseDefinitions` where raw database names from `sys.databases` were spliced into a `USE "..."` template without escaping. A principal with only `dbcreator` rights could create a database whose name contained arbitrary T-SQL, which the monitoring agent executed on every collection cycle. Fixed by switching to bracket-quoted identifiers (`USE [...]`) and escaping `]` → `]]` in `dbNameReplace`
+
 ### bugfix
 - Replaced `GETUTCDATE()` with `SYSDATETIME()` in DMV slow query lookback filter to correctly match `last_execution_time` (which is local server time) and prevent queries from being erroneously excluded on servers not in UTC
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ## Unreleased
 
 ### security
-- Fixed second-order SQL injection in `specificDatabaseDefinitions` where raw database names from `sys.databases` were spliced into a `USE "..."` template without escaping. A principal with only `dbcreator` rights could create a database whose name contained arbitrary T-SQL, which the monitoring agent executed on every collection cycle. Fixed by switching to bracket-quoted identifiers (`USE [...]`) and escaping `]` → `]]` in `dbNameReplace`
+- Fixed second-order SQL injection where raw database names from `sys.databases` were spliced into SQL templates without escaping. A principal with only `dbcreator` rights could create a database whose name contained arbitrary T-SQL, which the monitoring agent executed on every collection cycle. Fixed by switching to bracket-quoted identifiers (`USE [...]`) and escaping `]` → `]]` in `dbNameReplace` for reserved space metrics, and applying the same bracket-quoting in custom metrics database prefix construction
 
 ### bugfix
 - Replaced `GETUTCDATE()` with `SYSDATETIME()` in DMV slow query lookback filter to correctly match `last_execution_time` (which is local server time) and prevent queries from being erroneously excluded on servers not in UTC

--- a/src/metrics/database_metric_definitions.go
+++ b/src/metrics/database_metric_definitions.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/newrelic/nri-mssql/src/database"
@@ -29,11 +28,13 @@ type AvailablePhysicalMemoryModel struct {
 	AvailablePhysicalMemory *float64 `db:"available_physical_memory" metric_name:"memoryAvailable" source_type:"gauge"`
 }
 
-// dbNameReplace inserts the dbName into a query anywhere
-// databasePlaceHolder is present
+// dbNameReplace inserts the dbName into a query anywhere databasePlaceholder is
+// present. The name is bracket-escaped (] → ]]) so it is safe to embed inside a
+// [bracket-quoted] SQL Server identifier and cannot break out into a new statement.
 func dbNameReplace(dbName string) QueryModifier {
 	return func(query string) string {
-		return strings.ReplaceAll(query, databasePlaceholder, dbName)
+		escaped := strings.ReplaceAll(dbName, "]", "]]")
+		return strings.ReplaceAll(query, databasePlaceholder, escaped)
 	}
 }
 
@@ -183,7 +184,7 @@ var databaseBufferDefinitionsForAzureSQLDatabase = []*QueryDefinition{
 
 var specificDatabaseDefinitions = []*QueryDefinition{
 	{
-		query: fmt.Sprintf(`USE "%s"
+		query: `USE [%DATABASE%]
 		;WITH reserved_space(db_name, reserved_space_kb, reserved_space_not_used_kb)
 		AS
 		(
@@ -200,7 +201,7 @@ var specificDatabaseDefinitions = []*QueryDefinition{
 		max(reserved_space_kb) * 1024 AS reserved_space,
 		max(reserved_space_not_used_kb) * 1024 AS reserved_space_not_used
 		FROM reserved_space
-		GROUP BY db_name`, databasePlaceholder),
+		GROUP BY db_name`,
 		dataModels: &[]struct {
 			database.DataModel
 			ReservedSpace        float64 `db:"reserved_space" metric_name:"pageFileTotal" source_type:"gauge"`

--- a/src/metrics/database_metric_definitions_test.go
+++ b/src/metrics/database_metric_definitions_test.go
@@ -6,13 +6,41 @@ import (
 )
 
 func Test_dbNameReplace(t *testing.T) {
-
-	dbName, format := "master", "use %s select * from %s"
-	query := fmt.Sprintf(format, databasePlaceholder, databasePlaceholder)
+	// baseline: normal name is inserted verbatim (no ] to escape)
+	dbName, format := "master", "use [%s] select * from [%s]"
+	query := fmt.Sprintf("use [%s] select * from [%s]", databasePlaceholder, databasePlaceholder)
 	expected := fmt.Sprintf(format, dbName, dbName)
 
 	modifier := dbNameReplace(dbName)
 	if out := modifier(query); out != expected {
+		t.Errorf("Expected '%s' got '%s'", expected, out)
+	}
+}
+
+func Test_dbNameReplace_escapesClosingBracket(t *testing.T) {
+	// A ] in the name must be doubled so it cannot close the bracket-quoted identifier early.
+	modifier := dbNameReplace("test]db")
+	query := fmt.Sprintf("USE [%s]", databasePlaceholder)
+	out := modifier(query)
+	// ] → ]] so the identifier becomes [test]]db] which SQL Server reads as test]db
+	if out != "USE [test]]db]" {
+		t.Errorf("Expected 'USE [test]]db]' got '%s'", out)
+	}
+}
+
+func Test_dbNameReplace_neutralisesInjection(t *testing.T) {
+	// An attacker-controlled name containing SQL metacharacters must not produce
+	// a second executable statement when embedded inside [bracket-quoted] USE.
+	// The payload has no ] so no escaping is needed; the whole string is absorbed
+	// inside [brackets] as a single identifier — the ; and -- are not executable.
+	injected := `master";INSERT INTO evil SELECT secret FROM victim;--`
+	modifier := dbNameReplace(injected)
+	query := fmt.Sprintf("USE [%s]", databasePlaceholder)
+	out := modifier(query)
+
+	// The entire name must be wrapped inside [brackets] as one identifier.
+	expected := fmt.Sprintf("USE [%s]", injected)
+	if out != expected {
 		t.Errorf("Expected '%s' got '%s'", expected, out)
 	}
 }

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/newrelic/infra-integrations-sdk/v3/data/attribute"
@@ -173,7 +174,7 @@ func populateWaitTimeMetrics(instanceEntity *integration.Entity, connection *con
 func populateCustomMetrics(instanceEntity *integration.Entity, connection *connection.SQLConnection, query customQuery) {
 	var prefix string
 	if len(query.Database) > 0 {
-		prefix = "USE " + query.Database + "; "
+		prefix = "USE [" + strings.ReplaceAll(query.Database, "]", "]]") + "]; "
 	}
 
 	log.Debug("Running custom query: %+v", query)

--- a/src/metrics/metrics_test.go
+++ b/src/metrics/metrics_test.go
@@ -260,7 +260,7 @@ func setupMockForDatabaseMetrics(mock sqlmock.Sqlmock, logGrowthResp mockRespons
 	}
 
 	if args.EnableDatabaseReserveMetrics {
-		reserveRegex := `^(?:USE\s+"[^"]+"\s+;\s*)?(?:WITH\s+reserved_space.*)?SELECT\s+DB_NAME\([^)]*\)\s+AS\s+db_name.*reserved_space.*`
+		reserveRegex := `^(?:USE\s+\[[^\]]*\]\s*;\s*)?(?:WITH\s+reserved_space.*)?SELECT\s+DB_NAME\([^)]*\)\s+AS\s+db_name.*reserved_space.*`
 		mock.ExpectQuery(reserveRegex).
 			WillReturnRows(sqlmock.NewRows([]string{"db_name", "reserved_space", "reserved_space_not_used"}).AddRow("db-1", 0, 0))
 		mock.ExpectQuery(reserveRegex).


### PR DESCRIPTION
**Jira ticket:** https://new-relic.atlassian.net/browse/NR-581193
**Description:** prevent SQL injection via database name in `specificDatabaseDefinitions`:

**Issue:**

`dbNameReplace` spliced raw database names from `sys.databases` into USE `"%DATABASE%"` with no escaping. A principal with only `dbcreator` rights could create a database whose name contained injected T-SQL, which the monitoring agent (typically `sysadmin`) would execute on every collection cycle. Enabled by default via `EnableDatabaseReserveMetrics = true`.

**Fix:**
- Escape ] → ]] in `dbNameReplace` before the splice (matches SQL Server's QUOTENAME bracket-identifier behaviour)
- Switch template from `USE "%DATABASE%"` to `USE [%DATABASE%]` so injected characters like `"` and `;` are absorbed as part of the identifier name, not as SQL syntax