### PR TITLE
Add DatabaseName field to MSSQLQueryExecutionPlans event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Enhancements
+- Added `DatabaseName` field to `MSSQLQueryExecutionPlans` query.
+
 ## v2.34.0 - 2026-07-07
 
 ### 🛡️ Security notices

--- a/src/queryanalysis/config/query_config.go
+++ b/src/queryanalysis/config/query_config.go
@@ -490,15 +490,17 @@ TopPlans AS (
         qs.execution_count as execution_count,
         COALESCE((qs.total_elapsed_time / NULLIF(qs.execution_count, 0)) / 1000, 0) AS avg_elapsed_time_ms,
         qp.query_plan,
-        CONVERT(INT, pa.value) AS database_id
+        (
+            SELECT CONVERT(INT, value)
+            FROM sys.dm_exec_plan_attributes(qs.plan_handle)
+            WHERE attribute = 'dbid'
+        ) AS database_id
     FROM sys.dm_exec_query_stats AS qs
     CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
     CROSS APPLY sys.dm_exec_query_plan(qs.plan_handle) AS qp
-    CROSS APPLY sys.dm_exec_plan_attributes(qs.plan_handle) AS pa
 	WHERE qs.query_hash IN (SELECT QueryId FROM @QueryIdTable)
 	AND qs.last_execution_time BETWEEN DATEADD(SECOND, -@IntervalSeconds, SYSDATETIME()) AND SYSDATETIME()
     AND COALESCE((qs.total_elapsed_time / NULLIF(qs.execution_count, 0)) / 1000, 0) > @ElapsedTimeThreshold
-    AND pa.attribute = 'dbid'
     ORDER BY avg_elapsed_time_ms DESC
 ),
 PlanNodes AS (

--- a/src/queryanalysis/config/query_config.go
+++ b/src/queryanalysis/config/query_config.go
@@ -489,19 +489,23 @@ TopPlans AS (
         LEFT(st.text, @TextTruncateLimit) AS sql_text,
         qs.execution_count as execution_count,
         COALESCE((qs.total_elapsed_time / NULLIF(qs.execution_count, 0)) / 1000, 0) AS avg_elapsed_time_ms,
-        qp.query_plan
+        qp.query_plan,
+        CONVERT(INT, pa.value) AS database_id
     FROM sys.dm_exec_query_stats AS qs
     CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
     CROSS APPLY sys.dm_exec_query_plan(qs.plan_handle) AS qp
+    CROSS APPLY sys.dm_exec_plan_attributes(qs.plan_handle) AS pa
 	WHERE qs.query_hash IN (SELECT QueryId FROM @QueryIdTable)
 	AND qs.last_execution_time BETWEEN DATEADD(SECOND, -@IntervalSeconds, SYSDATETIME()) AND SYSDATETIME()
     AND COALESCE((qs.total_elapsed_time / NULLIF(qs.execution_count, 0)) / 1000, 0) > @ElapsedTimeThreshold
+    AND pa.attribute = 'dbid'
     ORDER BY avg_elapsed_time_ms DESC
 ),
 PlanNodes AS (
     SELECT
         tp.query_id,
         tp.sql_text,
+        DB_NAME(tp.database_id) AS database_name,
         tp.plan_handle,
         tp.query_plan_id,
         tp.avg_elapsed_time_ms,

--- a/src/queryanalysis/models/query_execution_plan.go
+++ b/src/queryanalysis/models/query_execution_plan.go
@@ -2,6 +2,7 @@ package models
 
 type ExecutionPlanResult struct {
 	SQLText                *string      `db:"sql_text" metric_name:"sql_text" source_type:"attribute"`
+	DatabaseName           *string      `db:"database_name" metric_name:"database_name" source_type:"attribute"`
 	QueryID                *HexString   `db:"query_id" metric_name:"query_id" source_type:"attribute"`
 	QueryPlanID            *HexString   `db:"query_plan_id" metric_name:"query_plan_id" source_type:"attribute"`
 	NodeID                 *int         `db:"NodeId" metric_name:"NodeId" source_type:"gauge"`

--- a/src/queryanalysis/utils/utils_test.go
+++ b/src/queryanalysis/utils/utils_test.go
@@ -30,7 +30,7 @@ func TestGenerateAndIngestExecutionPlan_Success(t *testing.T) {
 
 	mock.ExpectQuery(executionPlanQueryPattern).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"query_id", "sql_text", "plan_handle", "query_plan_id",
+			"query_id", "sql_text", "database_name", "plan_handle", "query_plan_id",
 			"avg_elapsed_time_ms", "execution_count", "NodeId",
 			"PhysicalOp", "LogicalOp", "EstimateRows",
 			"EstimateIO", "EstimateCPU", "AvgRowSize",
@@ -39,7 +39,7 @@ func TestGenerateAndIngestExecutionPlan_Success(t *testing.T) {
 			"SpillOccurred", "NoJoinPredicate",
 		}).
 			AddRow(
-				[]uint8{0x01, 0x02}, "SELECT * FROM table", []byte{0x01, 0x02},
+				[]uint8{0x01, 0x02}, "SELECT * FROM table", "testdb", []byte{0x01, 0x02},
 				[]uint8{0x01, 0x02, 0x03}, 100, 10,
 				1, "PhysicalOp1", "LogicalOp1", 100,
 				1.0, 0.5, 4.0, "Row",
@@ -98,7 +98,7 @@ func TestProcessExecutionPlans_Success(t *testing.T) {
 	// Mocking SQL response to match expected output
 	mock.ExpectQuery(executionPlanQueryPattern).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"query_id", "sql_text", "plan_handle", "query_plan_id",
+			"query_id", "sql_text", "database_name", "plan_handle", "query_plan_id",
 			"avg_elapsed_time_ms", "execution_count", "NodeId",
 			"PhysicalOp", "LogicalOp", "EstimateRows",
 			"EstimateIO", "EstimateCPU", "AvgRowSize",
@@ -107,7 +107,7 @@ func TestProcessExecutionPlans_Success(t *testing.T) {
 			"SpillOccurred", "NoJoinPredicate",
 		}).
 			AddRow(
-				[]uint8{0x01, 0x02}, "SELECT * FROM some_table", []byte{0x01, 0x02},
+				[]uint8{0x01, 0x02}, "SELECT * FROM some_table", "testdb", []byte{0x01, 0x02},
 				[]uint8{0x01, 0x02, 0x03}, 100, 10, // Replace with realistic/mock values
 				1, "PhysicalOp1", "LogicalOp1", 100,
 				1.0, 0.5, 4.0, "Row",

--- a/tests/testdata/execution-plan-schema.json
+++ b/tests/testdata/execution-plan-schema.json
@@ -55,6 +55,7 @@
                 "required": [
                   "AvgElapsedTimeMs",
                   "AvgRowSize",
+                  "DatabaseName",
                   "EstimateCPU",
                   "EstimateIO",
                   "EstimateRows",
@@ -85,6 +86,9 @@
                   },
                   "AvgRowSize": {
                     "type": "number"
+                  },
+                  "DatabaseName": {
+                    "type": "string"
                   },
                   "EstimateCPU": {
                     "type": "number"


### PR DESCRIPTION
## Summary
Add the `DatabaseName` field to `MSSQLQueryExecutionPlans` events, enabling users to filter and group execution plans by database.

## Test

- **Version**: Microsoft SQL Server 2022 (RTM build 16.0.1000.6)
- **Edition**: Developer Edition (which means you have access to all the high-end Enterprise features for testing and development)
- **Host OS**: Windows 10 Pro

**Results comparison (default vs new cross apply for database):**

Name | BEFORE | AFTER | Diff
-- | -- | -- | --
CPU time | 30,844 ms | 31,094 ms | +250 ms (~0.8%)
Elapsed time | 31,090 ms | 31,581 ms | +491 ms (~1.6%)
Logical reads (Worktable) | 91,649 | 91,649 | 0
LOB logical reads | 2,001,477 | 2,001,477 | 0
Rows returned | 724 | 724 | 0


**Before**:
<img width="1720" height="969" alt="Screenshot 2026-07-15 at 12 30 14 PM" src="https://github.com/user-attachments/assets/c99f724c-bdb1-4532-b51e-0ad89cc6c9e4" />
**After**:

<img width="1698" height="964" alt="Screenshot 2026-07-15 at 12 31 23 PM" src="https://github.com/user-attachments/assets/c531fb4b-dcf5-46dc-8860-e1244e18cfe4" />

**Results comparison (default vs scalar subquery + database_name)**
Name | BEFORE (default, no dbid) | AFTER (scalar subquery + database_name)
-- | -- | --
Rows returned | 905 | 905
Logical reads (Worktable) | 114,009 | 114,009
LOB logical reads | 2,530,753 | 2,530,753
CPU time | 38,891 ms | 38,688 ms
Elapsed time | 39,259 ms | 39,156 ms

**Default**:
<img width="1718" height="970" alt="Screenshot 2026-07-15 at 1 18 44 PM" src="https://github.com/user-attachments/assets/5bf640e1-3818-4f9d-8b12-a7696f5c5a47" />

**scalar subquery + database_name**
<img width="1710" height="963" alt="Screenshot 2026-07-15 at 1 19 38 PM" src="https://github.com/user-attachments/assets/3767ab2e-a0ea-4ecc-8266-4d1ab505c21b" />


**Screenshots**:

- **Before**:

<img width="1715" height="888" alt="Screenshot 2026-07-10 at 1 43 13 PM" src="https://github.com/user-attachments/assets/be9f5332-d8e6-43ba-af21-9223a2bc3db9" />

- **After**: 

<img width="1703" height="880" alt="Screenshot 2026-07-10 at 1 43 28 PM" src="https://github.com/user-attachments/assets/0285c2c0-885e-4ff2-a1f0-88979642bdc8" />
