### PR TITLE
add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/automated_release.yaml
+++ b/.github/workflows/automated_release.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "30 9 * * 2"
 
+permissions:
+  contents: write
+
 jobs:
   release_management:
     uses: newrelic/coreint-automation/.github/workflows/reusable_release_automation.yaml@v3

--- a/.github/workflows/on_prerelease.yaml
+++ b/.github/workflows/on_prerelease.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   pre-release:
     uses: newrelic/coreint-automation/.github/workflows/reusable_pre_release.yaml@v3

--- a/.github/workflows/on_push_pr.yaml
+++ b/.github/workflows/on_push_pr.yaml
@@ -8,6 +8,9 @@ on:
       - renovate/**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   push-pr:
     uses: newrelic/coreint-automation/.github/workflows/reusable_push_pr.yaml@v3

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     uses: newrelic/coreint-automation/.github/workflows/reusable_on_release.yaml@v3

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -6,6 +6,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   repolinter:
     uses: newrelic/coreint-automation/.github/workflows/reusable_repolinter.yaml@v3

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   security:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   security:
     uses: newrelic/coreint-automation/.github/workflows/reusable_security.yaml@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ## Unreleased
 
 ### Security
+- Added explicit least-privilege `permissions` blocks to GitHub Actions workflows
+
+### Security
 - Upgraded `golang.org/x/net` from v0.56.0 to v0.57.0 to fix [CVE-2026-46600](https://www.cve.org/CVERecord?id=CVE-2026-46600) (SVCB/HTTPS RR parsing panic), [CVE-2026-33814](https://www.cve.org/CVERecord?id=CVE-2026-33814) (HTTP/2 infinite loop), [CVE-2026-25680](https://www.cve.org/CVERecord?id=CVE-2026-25680) (HTML parser DoS), [CVE-2026-39821](https://www.cve.org/CVERecord?id=CVE-2026-39821) (IDNA privilege escalation), and multiple HTML XSS vulnerabilities ([CVE-2026-27136](https://www.cve.org/CVERecord?id=CVE-2026-27136), [CVE-2026-25681](https://www.cve.org/CVERecord?id=CVE-2026-25681), [CVE-2026-42502](https://www.cve.org/CVERecord?id=CVE-2026-42502), [CVE-2026-42506](https://www.cve.org/CVERecord?id=CVE-2026-42506))
 - Upgraded `golang.org/x/crypto` from v0.53.0 to v0.54.0
 - Upgraded `golang.org/x/sys` from v0.46.0 to v0.47.0


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to all workflow files missing a permissions block
- Follows the principle of least privilege for GitHub Actions tokens
- Resolves CodeQL alert `actions/missing-workflow-permissions` ([NR-560126](https://new-relic.atlassian.net/browse/NR-560126))

## Test plan
- [ ] Verify CI workflows still pass with the new permissions block
- [ ] Confirm CodeQL alert is resolved after merge

[NR-560126]: https://new-relic.atlassian.net/browse/NR-560126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ